### PR TITLE
Tuples should render as lists

### DIFF
--- a/solid/solidpython.py
+++ b/solid/solidpython.py
@@ -502,7 +502,7 @@ def py2openscad(o):
         return str(o).lower()
     if type(o) == float:
         return "%.10f" % o
-    if type(o) == list:
+    if type(o) == list or type(o) == tuple:
         s = "["
         first = True
         for i in o:


### PR DESCRIPTION
The tuple type does not exist in OpenSCAD,
but is a legal indexable object in Python that
can be exchanged for a list.

Without this patch, passing a list of tuples
or a tuple of tuples would result in invalid
OpenSCAD output.
