### PR TITLE
fix add_param('$fn' not converted to segments

### DIFF
--- a/solid/solidpython.py
+++ b/solid/solidpython.py
@@ -532,6 +532,8 @@ class openscad_object( object):
         self.parent = parent
     
     def add_param(self, k, v):
+        if k == '$fn':
+            k = 'segments'
         self.params[k] = v
         return self
     


### PR DESCRIPTION
Now correctly propagated to scad output.

Signed-off-by: Richard Marko <rmarko@fedoraproject.org>