### PR TITLE
adding initial support for IPython (Notebook)

### DIFF
--- a/solid/solidpython.py
+++ b/solid/solidpython.py
@@ -12,6 +12,11 @@
 import os, sys, re
 import inspect
 
+try:
+    import IPython
+except ImportError:
+    IPython = None
+
 openscad_builtins = [
     # 2D primitives
     {'name': 'polygon',         'args': ['points', 'paths'], 'kwargs': []} ,
@@ -630,7 +635,6 @@ class included_openscad_object( openscad_object):
         raise ValueError("Unable to find included SCAD file: "
                             "%(include_file_path)s in sys.path"%vars())
     
-
 def calling_module( stack_depth=2):
     '''
     Returns the module *2* back in the frame stack.  That means:
@@ -646,6 +650,11 @@ def calling_module( stack_depth=2):
     '''
     frm = inspect.stack()[stack_depth]
     calling_mod = inspect.getmodule( frm[0])
+
+    # IPython does its own weird things to the stack, but gives us an out
+    if IPython and not calling_mod and "ipython-input" in frm[1]:
+        calling_mod = IPython.get_ipython().user_module
+
     return calling_mod
 
 def new_openscad_class_str( class_name, args=[], kwargs=[], include_file_path=None, use_not_include=True):


### PR DESCRIPTION
## Observed Behavior
From within an IPython interactive session, `master` complains about `calling_module` returning `None` when many features (`use`, `include`, etc.) are called. 

## Proposed
This PR adds a small workaround that will try to use the current IPython user namespace if the module is `None`, and the frame bears IPython-y marks. It should have little impact beyond that

Currently, many features in `solid` require a real module for the stack to find. IPython, in emulating the REPL, does a lot of its own magic with the stack, which [`inspect.getmodule`](https://docs.python.org/2/library/inspect.html#inspect.getmodule) can't quite figure out: the behavior of that function is best-effort, anyway. 

I can add tests, if you would like, but then IPython would at least need to be added to the test regime. 

## Motivation
[IPython](http://ipython.org)/[Jupyter](http://jupyter.org) (specifically the notebook) offers a productive, interactive, web-based interface for writing, among other things, python. The notebook format is a JSON which stores code, narrative, and output. Recently, it was also added as a format directly rendered in Github (within limits, because XSS) but can also be viewed on [nbviewer](http://nbviewer.org). _Disclosure: i'm an nbviewer maintainer!_

## Appropriateness
While this could be implemented as a monkeypatch, I think there are enough people that will be experiencing Python for the first time through the notebook interface that I would hope you wouldn't mind including it.

## Future work
As I am experimenting, I will very likely gin up:
- some IPython widgets (think sliders, etc.) that control parameters, regenerate the file, causing the OpenSCAD GUI to update
- a BOM viewer
- an in-notebook STL viewer, perhaps [thingiviewer](http://wiki.ultimaker.com/thingiview.js/examples/client_side_ajax.html#)... likely this would still shell out to openscad to generate the file, but then it would become embedded in the notebook itself... great for sharing!

These kinds of features could easily be a separate module, e.g. `ipysolid` but I would be very happy to contribute them to this project, whether in some `contrib` section, or what have you.