### PR TITLE
adding _repr_png_ for ipython

### DIFF
--- a/solid/solidpython.py
+++ b/solid/solidpython.py
@@ -602,6 +602,34 @@ class OpenSCADObject(object):
         '''
         return intersection()(self, x)
 
+    def _repr_png_(self):
+        '''
+        Allow rich clients such as the IPython Notebook, to display the current
+        OpenSCAD rendering of this object.
+        '''
+        png_data = None
+        tmp = tempfile.NamedTemporaryFile(suffix=".scad", delete=False)
+        tmp_png = tempfile.NamedTemporaryFile(suffix=".png", delete=False)
+        try:
+            scad_text = scad_render(self).encode("utf-8")
+            tmp.write(scad_text)
+            tmp.close()
+            tmp_png.close()
+            subprocess.Popen([
+                "openscad",
+                "--preview",
+                "-o", tmp_png.name,
+                tmp.name
+            ]).communicate()
+
+            with open(tmp_png.name, "rb") as png:
+                png_data = png.read()
+        finally:
+            os.unlink(tmp.name)
+            os.unlink(tmp_png.name)
+
+        return png_data
+
 
 class IncludedOpenSCADObject(OpenSCADObject):
 

--- a/solid/solidpython.py
+++ b/solid/solidpython.py
@@ -11,6 +11,8 @@
 
 import os, sys, re
 import inspect
+import subprocess
+import tempfile
 
 openscad_builtins = [
     # 2D primitives


### PR DESCRIPTION
## Motiviation
When using SolidPython in the IPython Notebook, it would be nice if just typing:
```python
cube([1,1,1])
```
would draw the object. Additionally, it would be nice to have these images persist through to nbviewer.

## Integration
This follows the approach from the [IPython documentation](http://nbviewer.ipython.org/github/ipython/ipython/blob/master/examples/IPython%20Kernel/Custom%20Display%20Logic.ipynb) to add a custom PNG renderer to `OpenSCADObject`, which everything the user sees appears to inherit from... thanks for that!

## Implementation
The `_repr_png_` basically shells out to openscad to generate a PNG, using two temporary files, then pushes the raw binary out. The notebook then stores this as base64 encoded data. It would be lovely to do some compression up front, but that would introduce icky dependencies...

## Demo
Here is an example notebook:
http://nbviewer.ipython.org/gist/bollwyvl/dc849c324ba80bdce771

## Future Work
When a suitable browser-based, repackageable STL renderer has been discovered, an `_repr_html_` could be added/replace the png one. There would be the question of CDN vs. inlining.

## Open questions
How would you like to handle configuration? The manpage for openscad has a number of lovely options, like colorscheme, image size and camera stuff... but not axes :disappointed:. solid.openscad_params? I guess the "gold bricks" color scheme is fine for now. 