### PR TITLE
Added extra imports needed to  run example code.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,6 +66,8 @@ compiles to:
 
 ::
 
+    from solid import *
+    from solid.utils import *
     d = cube(5) + right(5)(sphere(5)) - cylinder(r=2, h=6)
 
 Generates this OpenSCAD code:


### PR DESCRIPTION
The example is later repeated but the solid.utils is not mentioned and the example has a right(5) that avoids the sample code to run.
