### PR TITLE
Add some scad-utils operations

### DIFF
--- a/solid/solidpython.py
+++ b/solid/solidpython.py
@@ -1000,6 +1000,50 @@ class hull(OpenSCADObject):
         OpenSCADObject.__init__(self, 'hull', {})
 
 
+class inset(OpenSCADObject):
+    '''
+    Creates a polygon at an offset `d` inside a 2D shape.
+
+    :param d: offset
+    :type d: number
+    '''
+    def __init__(self, d=None):
+        OpenSCADObject.__init__(self, 'inset', {'d': d})
+
+
+class outset(OpenSCADObject):
+    '''
+    Creates a polygon at an offset `d` outside a 2D shape.
+
+    :param d: offset
+    :type d: number
+    '''
+    def __init__(self, d=None):
+        OpenSCADObject.__init__(self, 'outset', {'d': d})
+
+
+class fillet(OpenSCADObject):
+    '''
+    Adds fillets of radius `r` to all concave corners of a 2D shape.
+
+    :param r: radius
+    :type r: number
+    '''
+    def __init__(self, r=None):
+        OpenSCADObject.__init__(self, 'fillet', {'r': r})
+
+
+class rounding(OpenSCADObject):
+    '''
+    Adds rounding of radius `r` to all convex corners of a 2D shape.
+
+    :param r: radius
+    :type r: number
+    '''
+    def __init__(self, r=None):
+        OpenSCADObject.__init__(self, 'rounding', {'r': r})
+
+
 class render(OpenSCADObject):
     '''
     Always calculate the CSG model for this tree (even in OpenCSG preview


### PR DESCRIPTION
[SCAD utils](https://github.com/OskarLinde/scad-utils) implements some useful operations like inset, outset, fillet and rounding.

Would it make sense to include them in SolidPython? They are planned to be included in OpenSCAD some day, but they are still a separate project. However, I see no harm in including them in SolidPython for now (if you want to use them you just need to make sure the OpenSCAD utils code is available, of course).