### PR TITLE
only transformations are callable

### DIFF
--- a/solid/objects.py
+++ b/solid/objects.py
@@ -1,7 +1,7 @@
 """
 Classes for OpenSCAD builtins
 """
-from .solidpython import OpenSCADObject
+from .solidpython import OpenSCADObject, OpenSCADTransformation
 from .solidpython import IncludedOpenSCADObject
 
 class polygon(OpenSCADObject):
@@ -160,7 +160,7 @@ class polyhedron(OpenSCADObject):
                                  'triangles': triangles})
 
 
-class union(OpenSCADObject):
+class union(OpenSCADTransformation):
     '''
     Creates a union of all its child nodes. This is the **sum** of all
     children.
@@ -169,7 +169,7 @@ class union(OpenSCADObject):
         OpenSCADObject.__init__(self, 'union', {})
 
 
-class intersection(OpenSCADObject):
+class intersection(OpenSCADTransformation):
     '''
     Creates the intersection of all child nodes. This keeps the
     **overlapping** portion
@@ -178,7 +178,7 @@ class intersection(OpenSCADObject):
         OpenSCADObject.__init__(self, 'intersection', {})
 
 
-class difference(OpenSCADObject):
+class difference(OpenSCADTransformation):
     '''
     Subtracts the 2nd (and all further) child nodes from the first one.
     '''
@@ -186,19 +186,19 @@ class difference(OpenSCADObject):
         OpenSCADObject.__init__(self, 'difference', {})
 
 
-class hole(OpenSCADObject):
+class hole(OpenSCADTransformation):
     def __init__(self):
         OpenSCADObject.__init__(self, 'hole', {})
         self.set_hole(True)
 
 
-class part(OpenSCADObject):
+class part(OpenSCADTransformation):
     def __init__(self):
         OpenSCADObject.__init__(self, 'part', {})
         self.set_part_root(True)
 
 
-class translate(OpenSCADObject):
+class translate(OpenSCADTransformation):
     '''
     Translates (moves) its child elements along the specified vector.
 
@@ -209,7 +209,7 @@ class translate(OpenSCADObject):
         OpenSCADObject.__init__(self, 'translate', {'v': v})
 
 
-class scale(OpenSCADObject):
+class scale(OpenSCADTransformation):
     '''
     Scales its child elements using the specified vector.
 
@@ -220,7 +220,7 @@ class scale(OpenSCADObject):
         OpenSCADObject.__init__(self, 'scale', {'v': v})
 
 
-class rotate(OpenSCADObject):
+class rotate(OpenSCADTransformation):
     '''
     Rotates its child 'a' degrees about the origin of the coordinate system
     or around an arbitrary axis.
@@ -235,7 +235,7 @@ class rotate(OpenSCADObject):
         OpenSCADObject.__init__(self, 'rotate', {'a': a, 'v': v})
 
 
-class mirror(OpenSCADObject):
+class mirror(OpenSCADTransformation):
     '''
     Mirrors the child element on a plane through the origin.
 
@@ -247,7 +247,7 @@ class mirror(OpenSCADObject):
         OpenSCADObject.__init__(self, 'mirror', {'v': v})
 
 
-class resize(OpenSCADObject):
+class resize(OpenSCADTransformation):
     '''
     Modify the size of the child object to match the given new size.
 
@@ -258,7 +258,7 @@ class resize(OpenSCADObject):
         OpenSCADObject.__init__(self, 'resize', {'newsize': newsize})
 
 
-class multmatrix(OpenSCADObject):
+class multmatrix(OpenSCADTransformation):
     '''
     Multiplies the geometry of all child elements with the given 4x4
     transformation matrix.
@@ -270,7 +270,7 @@ class multmatrix(OpenSCADObject):
         OpenSCADObject.__init__(self, 'multmatrix', {'m': m})
 
 
-class color(OpenSCADObject):
+class color(OpenSCADTransformation):
     '''
     Displays the child elements using the specified RGB color + alpha value.
     This is only used for the F5 preview as CGAL and STL (F6) do not
@@ -284,7 +284,7 @@ class color(OpenSCADObject):
         OpenSCADObject.__init__(self, 'color', {'c': c})
 
 
-class minkowski(OpenSCADObject):
+class minkowski(OpenSCADTransformation):
     '''
     Renders the `minkowski
     sum <http://www.cgal.org/Manual/latest/doc_html/cgal_manual/Minkowski_sum_3/Chapter_main.html>`__
@@ -293,7 +293,7 @@ class minkowski(OpenSCADObject):
     def __init__(self):
         OpenSCADObject.__init__(self, 'minkowski', {})
 
-class offset(OpenSCADObject):
+class offset(OpenSCADTransformation):
     '''
     
     :param r: Amount to offset the polygon (rounded corners). When negative, 
@@ -320,7 +320,7 @@ class offset(OpenSCADObject):
             raise ValueError("offset(): Must supply r or delta")
         OpenSCADObject.__init__(self, 'offset', kwargs)
 
-class hull(OpenSCADObject):
+class hull(OpenSCADTransformation):
     '''
     Renders the `convex
     hull <http://www.cgal.org/Manual/latest/doc_html/cgal_manual/Convex_hull_2/Chapter_main.html>`__
@@ -330,7 +330,7 @@ class hull(OpenSCADObject):
         OpenSCADObject.__init__(self, 'hull', {})
 
 
-class render(OpenSCADObject):
+class render(OpenSCADTransformation):
     '''
     Always calculate the CSG model for this tree (even in OpenCSG preview
     mode).
@@ -342,7 +342,7 @@ class render(OpenSCADObject):
         OpenSCADObject.__init__(self, 'render', {'convexity': convexity})
 
 
-class linear_extrude(OpenSCADObject):
+class linear_extrude(OpenSCADTransformation):
     '''
     Linear Extrusion is a modeling operation that takes a 2D polygon as
     input and extends it in the third dimension. This way a 3D shape is
@@ -375,7 +375,7 @@ class linear_extrude(OpenSCADObject):
                                  'slices': slices, 'scale':scale})
 
 
-class rotate_extrude(OpenSCADObject):
+class rotate_extrude(OpenSCADTransformation):
     '''
     A rotational extrusion is a Linear Extrusion with a twist, literally.
     Unfortunately, it can not be used to produce a helix for screw threads
@@ -401,7 +401,7 @@ class rotate_extrude(OpenSCADObject):
                                 {'convexity': convexity, 'segments': segments})
 
 
-class dxf_linear_extrude(OpenSCADObject):
+class dxf_linear_extrude(OpenSCADTransformation):
     def __init__(self, file, layer=None, height=None, center=None,
                  convexity=None, twist=None, slices=None):
         OpenSCADObject.__init__(self, 'dxf_linear_extrude',
@@ -411,7 +411,7 @@ class dxf_linear_extrude(OpenSCADObject):
                                  'slices': slices})
 
 
-class projection(OpenSCADObject):
+class projection(OpenSCADTransformation):
     '''
     Creates 2d shapes from 3d models, and export them to the dxf format.
     It works by projecting a 3D model to the (x,y) plane, with z at 0.
@@ -423,7 +423,7 @@ class projection(OpenSCADObject):
         OpenSCADObject.__init__(self, 'projection', {'cut': cut})
 
 
-class surface(OpenSCADObject):
+class surface(OpenSCADTransformation):
     '''
     Surface reads information from text or image files.
 
@@ -548,7 +548,7 @@ class import_(OpenSCADObject):
                                  'layer': layer})
 
 
-class intersection_for(OpenSCADObject):
+class intersection_for(OpenSCADTransformation):
     '''
     Iterate over the values in a vector or range and take an
     intersection of the contents.
@@ -557,7 +557,7 @@ class intersection_for(OpenSCADObject):
         OpenSCADObject.__init__(self, 'intersection_for', {'n': n})
 
 
-class assign(OpenSCADObject):
+class assign(OpenSCADTransformation):
     def __init__(self):
         OpenSCADObject.__init__(self, 'assign', {})
 

--- a/solid/objects.py
+++ b/solid/objects.py
@@ -1,7 +1,8 @@
 """
 Classes for OpenSCAD builtins
 """
-from .solidpython import OpenSCADObject, OpenSCADTransformation
+from .solidpython import OpenSCADObject
+from .solidpython import OpenSCADTransformation
 from .solidpython import IncludedOpenSCADObject
 
 class polygon(OpenSCADObject):

--- a/solid/objects.py
+++ b/solid/objects.py
@@ -167,7 +167,7 @@ class union(OpenSCADTransformation):
     children.
     '''
     def __init__(self):
-        OpenSCADObject.__init__(self, 'union', {})
+        OpenSCADTransformation.__init__(self, 'union', {})
 
 
 class intersection(OpenSCADTransformation):
@@ -176,7 +176,7 @@ class intersection(OpenSCADTransformation):
     **overlapping** portion
     '''
     def __init__(self):
-        OpenSCADObject.__init__(self, 'intersection', {})
+        OpenSCADTransformation.__init__(self, 'intersection', {})
 
 
 class difference(OpenSCADTransformation):
@@ -184,18 +184,18 @@ class difference(OpenSCADTransformation):
     Subtracts the 2nd (and all further) child nodes from the first one.
     '''
     def __init__(self):
-        OpenSCADObject.__init__(self, 'difference', {})
+        OpenSCADTransformation.__init__(self, 'difference', {})
 
 
 class hole(OpenSCADTransformation):
     def __init__(self):
-        OpenSCADObject.__init__(self, 'hole', {})
+        OpenSCADTransformation.__init__(self, 'hole', {})
         self.set_hole(True)
 
 
 class part(OpenSCADTransformation):
     def __init__(self):
-        OpenSCADObject.__init__(self, 'part', {})
+        OpenSCADTransformation.__init__(self, 'part', {})
         self.set_part_root(True)
 
 
@@ -207,7 +207,7 @@ class translate(OpenSCADTransformation):
     :type v: 3 value sequence
     '''
     def __init__(self, v=None):
-        OpenSCADObject.__init__(self, 'translate', {'v': v})
+        OpenSCADTransformation.__init__(self, 'translate', {'v': v})
 
 
 class scale(OpenSCADTransformation):
@@ -218,7 +218,7 @@ class scale(OpenSCADTransformation):
     :type v: 3 value sequence
     '''
     def __init__(self, v=None):
-        OpenSCADObject.__init__(self, 'scale', {'v': v})
+        OpenSCADTransformation.__init__(self, 'scale', {'v': v})
 
 
 class rotate(OpenSCADTransformation):
@@ -233,7 +233,7 @@ class rotate(OpenSCADTransformation):
     :type v: 3 value sequence
     '''
     def __init__(self, a=None, v=None):
-        OpenSCADObject.__init__(self, 'rotate', {'a': a, 'v': v})
+        OpenSCADTransformation.__init__(self, 'rotate', {'a': a, 'v': v})
 
 
 class mirror(OpenSCADTransformation):
@@ -245,7 +245,7 @@ class mirror(OpenSCADTransformation):
 
     '''
     def __init__(self, v):
-        OpenSCADObject.__init__(self, 'mirror', {'v': v})
+        OpenSCADTransformation.__init__(self, 'mirror', {'v': v})
 
 
 class resize(OpenSCADTransformation):
@@ -256,7 +256,7 @@ class resize(OpenSCADTransformation):
     :type newsize: 3 value sequence
     '''
     def __init__(self, newsize):
-        OpenSCADObject.__init__(self, 'resize', {'newsize': newsize})
+        OpenSCADTransformation.__init__(self, 'resize', {'newsize': newsize})
 
 
 class multmatrix(OpenSCADTransformation):
@@ -268,7 +268,7 @@ class multmatrix(OpenSCADTransformation):
     :type m: sequence of 4 sequences, each containing 4 numbers.
     '''
     def __init__(self, m):
-        OpenSCADObject.__init__(self, 'multmatrix', {'m': m})
+        OpenSCADTransformation.__init__(self, 'multmatrix', {'m': m})
 
 
 class color(OpenSCADTransformation):
@@ -282,7 +282,7 @@ class color(OpenSCADTransformation):
     :type c: sequence of 3 or 4 numbers between 0 and 1
     '''
     def __init__(self, c):
-        OpenSCADObject.__init__(self, 'color', {'c': c})
+        OpenSCADTransformation.__init__(self, 'color', {'c': c})
 
 
 class minkowski(OpenSCADTransformation):
@@ -292,7 +292,7 @@ class minkowski(OpenSCADTransformation):
     of child nodes.
     '''
     def __init__(self):
-        OpenSCADObject.__init__(self, 'minkowski', {})
+        OpenSCADTransformation.__init__(self, 'minkowski', {})
 
 class offset(OpenSCADTransformation):
     '''
@@ -319,7 +319,7 @@ class offset(OpenSCADTransformation):
             kwargs = {'delta':delta, 'chamfer':chamfer}
         else:
             raise ValueError("offset(): Must supply r or delta")
-        OpenSCADObject.__init__(self, 'offset', kwargs)
+            OpenSCADTransformation.__init__(self, 'offset', kwargs)
 
 class hull(OpenSCADTransformation):
     '''
@@ -328,7 +328,7 @@ class hull(OpenSCADTransformation):
     of child nodes.
     '''
     def __init__(self):
-        OpenSCADObject.__init__(self, 'hull', {})
+        OpenSCADTransformation.__init__(self, 'hull', {})
 
 
 class render(OpenSCADTransformation):
@@ -340,7 +340,7 @@ class render(OpenSCADTransformation):
     :type convexity: int
     '''
     def __init__(self, convexity=None):
-        OpenSCADObject.__init__(self, 'render', {'convexity': convexity})
+        OpenSCADTransformation.__init__(self, 'render', {'convexity': convexity})
 
 
 class linear_extrude(OpenSCADTransformation):
@@ -370,7 +370,7 @@ class linear_extrude(OpenSCADTransformation):
     '''
     def __init__(self, height=None, center=None, convexity=None, twist=None,
                  slices=None, scale=None):
-        OpenSCADObject.__init__(self, 'linear_extrude',
+        OpenSCADTransformation.__init__(self, 'linear_extrude',
                                 {'height': height, 'center': center,
                                  'convexity': convexity, 'twist': twist,
                                  'slices': slices, 'scale':scale})
@@ -398,14 +398,14 @@ class rotate_extrude(OpenSCADTransformation):
 
     '''
     def __init__(self, convexity=None, segments=None):
-        OpenSCADObject.__init__(self, 'rotate_extrude',
+        OpenSCADTransformation.__init__(self, 'rotate_extrude',
                                 {'convexity': convexity, 'segments': segments})
 
 
 class dxf_linear_extrude(OpenSCADTransformation):
     def __init__(self, file, layer=None, height=None, center=None,
                  convexity=None, twist=None, slices=None):
-        OpenSCADObject.__init__(self, 'dxf_linear_extrude',
+        OpenSCADTransformation.__init__(self, 'dxf_linear_extrude',
                                 {'file': file, 'layer': layer,
                                  'height': height, 'center': center,
                                  'convexity': convexity, 'twist': twist,
@@ -421,7 +421,7 @@ class projection(OpenSCADTransformation):
     :type cut: boolean
     '''
     def __init__(self, cut=None):
-        OpenSCADObject.__init__(self, 'projection', {'cut': cut})
+        OpenSCADTransformation.__init__(self, 'projection', {'cut': cut})
 
 
 class surface(OpenSCADTransformation):
@@ -441,7 +441,7 @@ class surface(OpenSCADTransformation):
     :type convexity: int
     '''
     def __init__(self, file, center=None, convexity=None, invert=None):
-        OpenSCADObject.__init__(self, 'surface',
+        OpenSCADTransformation.__init__(self, 'surface',
                                 {'file': file, 'center': center,
                                  'convexity': convexity, 'invert': invert})
 
@@ -555,12 +555,12 @@ class intersection_for(OpenSCADTransformation):
     intersection of the contents.
     '''
     def __init__(self, n):
-        OpenSCADObject.__init__(self, 'intersection_for', {'n': n})
+        OpenSCADTransformation.__init__(self, 'intersection_for', {'n': n})
 
 
 class assign(OpenSCADTransformation):
     def __init__(self):
-        OpenSCADObject.__init__(self, 'assign', {})
+        OpenSCADTransformation.__init__(self, 'assign', {})
 
 # ================================
 # = Modifier Convenience Methods =

--- a/solid/objects.py
+++ b/solid/objects.py
@@ -331,7 +331,7 @@ class offset(OpenSCADTransformation):
             kwargs = {'delta':delta, 'chamfer':chamfer}
         else:
             raise ValueError("offset(): Must supply r or delta")
-            OpenSCADTransformation.__init__(self, 'offset', kwargs)
+        OpenSCADTransformation.__init__(self, 'offset', kwargs)
 
 class hull(OpenSCADTransformation):
     '''
@@ -436,7 +436,7 @@ class projection(OpenSCADTransformation):
         OpenSCADTransformation.__init__(self, 'projection', {'cut': cut})
 
 
-class surface(OpenSCADTransformation):
+class surface(OpenSCADObject):
     '''
     Surface reads information from text or image files.
 
@@ -453,7 +453,7 @@ class surface(OpenSCADTransformation):
     :type convexity: int
     '''
     def __init__(self, file, center=None, convexity=None, invert=None):
-        OpenSCADTransformation.__init__(self, 'surface',
+        OpenSCADObject.__init__(self, 'surface',
                                 {'file': file, 'center': center,
                                  'convexity': convexity, 'invert': invert})
 

--- a/solid/solidpython.py
+++ b/solid/solidpython.py
@@ -543,7 +543,7 @@ class OpenSCADTransformation(OpenSCADObject):
         for child in self.children:
             if child.is_hole:
                 s += child._render(render_holes=True)
-            elif child.has_hole_children:
+            elif isinstance(child, OpenSCADTransformation) and child.has_hole_children:
                 # Holes exist in the compiled tree in two pieces:
                 # The shapes of the holes themselves, (an object for which
                 # obj.is_hole is True, and all its children) and the

--- a/solid/solidpython.py
+++ b/solid/solidpython.py
@@ -99,7 +99,7 @@ def scad_render_animated(func_to_animate, steps=20, back_and_forth=True, filepat
         scad_obj = func_to_animate(_time=eval_time)
 
         scad_str = indent(scad_obj._render())
-        rendered_string += ("if ($t >= %(time)s && $t < %(end_time)s){"
+        rendered_string += ("if ($t >= %(time)s && $t < %(end_time)s) {"
                             "   %(scad_str)s\n"
                             "}\n" % vars())
     return rendered_string
@@ -531,7 +531,7 @@ class OpenSCADTransformation(OpenSCADObject):
                 s += self._render_hole_children()
 
                 # wrap everything in the difference
-                s = "\ndifference(){" + indent(s) + " /* End Holes */ \n}"
+                s = "\ndifference() {" + indent(s) + " /* End Holes */ \n}"
         return s
 
     def _render_hole_children(self):
@@ -568,7 +568,7 @@ class OpenSCADTransformation(OpenSCADObject):
         if self.name in non_rendered_classes:
             pass
         else:
-            s = self._render_str_no_children() + "{" + indent(s) + "\n}"
+            s = self._render_str_no_children() + " {" + indent(s) + "\n}"
         return s
 
     def find_hole_children(self, path=None):

--- a/solid/solidpython.py
+++ b/solid/solidpython.py
@@ -511,17 +511,6 @@ class OpenSCADObject(object):
             other.add(c.copy())
         return other
 
-    def __call__(self, *args):
-        '''
-        Adds all objects in args to self.  This enables OpenSCAD-like syntax,
-        e.g.:
-        union()(
-            cube(),
-            sphere()
-        )
-        '''
-        return self.add(args)
-
     def __add__(self, x):
         '''
         This makes u = a+b identical to:
@@ -570,6 +559,18 @@ class OpenSCADObject(object):
             os.unlink(tmp_png.name)
 
         return png_data
+
+class OpenSCADTransformation(OpenSCADObject):
+    def __call__(self, *args):
+        '''
+        Adds all objects in args to self.  This enables OpenSCAD-like syntax,
+        e.g.:
+        union()(
+            cube(),
+            sphere()
+        )
+        '''
+        return self.add(args)
 
 
 class IncludedOpenSCADObject(OpenSCADObject):

--- a/solid/test/test_solidpython.py
+++ b/solid/test/test_solidpython.py
@@ -20,29 +20,28 @@ scad_test_case_templates = [
 {'name': 'cylinder',    'kwargs': {'r1': None, 'r2': None, 'h': 1, 'segments': 12, 'r': 1, 'center': False}, 'expected': '\n\ncylinder($fn = 12, center = false, h = 1, r = 1);', 'args': {}, },
 {'name': 'cylinder',    'kwargs': {'d1': 4, 'd2': 2, 'h': 1, 'segments': 12, 'center': False}, 'expected': '\n\ncylinder($fn = 12, center = false, d1 = 4, d2 = 2, h = 1);', 'args': {}, },
 {'name': 'polyhedron',  'kwargs': {'convexity': None}, 'expected': '\n\npolyhedron(faces = [[0, 1, 2]], points = [[0, 0, 0], [1, 0, 0], [0, 1, 0]]);', 'args': {'points': [[0, 0, 0], [1, 0, 0], [0, 1, 0]], 'faces': [[0, 1, 2]]}, },
-{'name': 'union',       'kwargs': {}, 'expected': '\n\nunion();', 'args': {}, },
-{'name': 'intersection','kwargs': {}, 'expected': '\n\nintersection();', 'args': {}, },
-{'name': 'difference',  'kwargs': {}, 'expected': '\n\ndifference();', 'args': {}, },
-{'name': 'translate',   'kwargs': {'v': [1, 0, 0]}, 'expected': '\n\ntranslate(v = [1, 0, 0]);', 'args': {}, },
-{'name': 'scale',       'kwargs': {'v': 0.5}, 'expected': '\n\nscale(v = 0.5000000000);', 'args': {}, },
-{'name': 'rotate',      'kwargs': {'a': 45, 'v': [0, 0, 1]}, 'expected': '\n\nrotate(a = 45, v = [0, 0, 1]);', 'args': {}, },
-{'name': 'mirror',      'kwargs': {}, 'expected': '\n\nmirror(v = [0, 0, 1]);', 'args': {'v': [0, 0, 1]}, },
-{'name': 'resize',      'kwargs': {'newsize':[5,5,5], 'auto':[True, True, False]}, 'expected': '\n\nresize(auto = [true, true, false], newsize = [5, 5, 5]);', 'args': {}, },
-{'name': 'multmatrix',  'kwargs': {}, 'expected': '\n\nmultmatrix(m = [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]);', 'args': {'m': [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]}, },
-{'name': 'color',       'kwargs': {}, 'expected': '\n\ncolor(c = [1, 0, 0]);', 'args': {'c': [1, 0, 0]}, },
-{'name': 'minkowski',   'kwargs': {}, 'expected': '\n\nminkowski();', 'args': {}, },
-{'name': 'offset',      'kwargs': {'r': 1}, 'expected': '\n\noffset(r = 1);', 'args': {}, },
-{'name': 'offset',      'kwargs': {'delta': 1}, 'expected': '\n\noffset(chamfer = false, delta = 1);', 'args': {}, },
-{'name': 'hull',        'kwargs': {}, 'expected': '\n\nhull();', 'args': {}, },
-{'name': 'render',      'kwargs': {'convexity': None}, 'expected': '\n\nrender();', 'args': {}, },
-{'name': 'projection',  'kwargs': {'cut': None}, 'expected': '\n\nprojection();', 'args': {}, },
+{'name': 'union',       'kwargs': {}, 'expected': '\n\nunion() {\n}', 'args': {}, },
+{'name': 'intersection','kwargs': {}, 'expected': '\n\nintersection() {\n}', 'args': {}, },
+{'name': 'difference',  'kwargs': {}, 'expected': '\n\ndifference() {\n}', 'args': {}, },
+{'name': 'translate',   'kwargs': {'v': [1, 0, 0]}, 'expected': '\n\ntranslate(v = [1, 0, 0]) {\n}', 'args': {}, },
+{'name': 'scale',       'kwargs': {'v': 0.5}, 'expected': '\n\nscale(v = 0.5000000000) {\n}', 'args': {}, },
+{'name': 'rotate',      'kwargs': {'a': 45, 'v': [0, 0, 1]}, 'expected': '\n\nrotate(a = 45, v = [0, 0, 1]) {\n}', 'args': {}, },
+{'name': 'mirror',      'kwargs': {}, 'expected': '\n\nmirror(v = [0, 0, 1]) {\n}', 'args': {'v': [0, 0, 1]}, },
+{'name': 'multmatrix',  'kwargs': {}, 'expected': '\n\nmultmatrix(m = [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]) {\n}', 'args': {'m': [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]}, },
+{'name': 'color',       'kwargs': {}, 'expected': '\n\ncolor(c = [1, 0, 0]) {\n}', 'args': {'c': [1, 0, 0]}, },
+{'name': 'minkowski',   'kwargs': {}, 'expected': '\n\nminkowski() {\n}', 'args': {}, },
+{'name': 'offset',      'kwargs': {'r': 1}, 'expected': '\n\noffset(r = 1) {\n}', 'args': {}, },
+{'name': 'offset',      'kwargs': {'delta': 1}, 'expected': '\n\noffset(chamfer = false, delta = 1) {\n}', 'args': {}, },
+{'name': 'hull',        'kwargs': {}, 'expected': '\n\nhull() {\n}', 'args': {}, },
+{'name': 'render',      'kwargs': {'convexity': None}, 'expected': '\n\nrender() {\n}', 'args': {}, },
+{'name': 'projection',  'kwargs': {'cut': None}, 'expected': '\n\nprojection() {\n}', 'args': {}, },
 {'name': 'surface',     'kwargs': {'center': False, 'convexity': None}, 'expected': '\n\nsurface(center = false, file = "/Path/to/dummy.dxf");', 'args': {'file': "'/Path/to/dummy.dxf'"}, },
 {'name': 'import_stl',  'kwargs': {'layer': None, 'origin': (0,0)}, 'expected': '\n\nimport(file = "/Path/to/dummy.stl", origin = [0, 0]);', 'args': {'file': "'/Path/to/dummy.stl'"}, },
 {'name': 'import_dxf',  'kwargs': {'layer': None, 'origin': (0,0)}, 'expected': '\n\nimport(file = "/Path/to/dummy.dxf", origin = [0, 0]);', 'args': {'file': "'/Path/to/dummy.dxf'"}, },
 {'name': 'import_',     'kwargs': {'layer': None, 'origin': (0,0)}, 'expected': '\n\nimport(file = "/Path/to/dummy.dxf", origin = [0, 0]);', 'args': {'file': "'/Path/to/dummy.dxf'"}, },
-{'name': 'linear_extrude',      'kwargs': {'twist': None, 'slices': None, 'center': False, 'convexity': None, 'height': 1, 'scale': 0.9}, 'expected': '\n\nlinear_extrude(center = false, height = 1, scale = 0.9000000000);', 'args': {}, },
-{'name': 'rotate_extrude',      'kwargs': {'convexity': None}, 'expected': '\n\nrotate_extrude();', 'args': {}, },
-{'name': 'intersection_for',    'kwargs': {}, 'expected': '\n\nintersection_for(n = [0, 1, 2]);', 'args': {'n': [0, 1, 2]}, },
+{'name': 'linear_extrude',      'kwargs': {'twist': None, 'slices': None, 'center': False, 'convexity': None, 'height': 1, 'scale': 0.9}, 'expected': '\n\nlinear_extrude(center = false, height = 1, scale = 0.9000000000) {\n}', 'args': {}, },
+{'name': 'rotate_extrude',      'kwargs': {'convexity': None}, 'expected': '\n\nrotate_extrude() {\n}', 'args': {}, },
+{'name': 'intersection_for',    'kwargs': {}, 'expected': '\n\nintersection_for(n = [0, 1, 2]) {\n}', 'args': {'n': [0, 1, 2]}, },
 ]
 
 class TemporaryFileBuffer(object):
@@ -176,7 +175,7 @@ class TestSolidPython(DiffOutput):
 
     def test_explicit_hole(self):
         a = cube(10, center=True) + hole()(cylinder(2, 20, center=True))
-        expected = '\n\ndifference(){\n\tunion() {\n\t\tcube(center = true, size = 10);\n\t}\n\t/* Holes Below*/\n\tunion(){\n\t\tcylinder(center = true, h = 20, r = 2);\n\t} /* End Holes */ \n}'
+        expected = '\n\ndifference() {\n\tunion() {\n\t\tcube(center = true, size = 10);\n\t}\n\t/* Holes Below*/\n\tunion() {\n\t\tcylinder(center = true, h = 20, r = 2);\n\t} /* End Holes */ \n}'
         actual = scad_render(a)
         self.assertEqual(expected, actual)
 
@@ -195,7 +194,7 @@ class TestSolidPython(DiffOutput):
         )
 
         a = cube(10, center=True) + h + h_vert
-        expected = '\n\ndifference(){\n\tunion() {\n\t\tcube(center = true, size = 10);\n\t\trotate(a = -90, v = [0, 1, 0]) {\n\t\t}\n\t}\n\t/* Holes Below*/\n\tunion(){\n\t\trotate(a = 90, v = [0, 1, 0]) {\n\t\t\tcylinder(center = true, h = 20, r = 2);\n\t\t}\n\t\trotate(a = -90, v = [0, 1, 0]){\n\t\t\trotate(a = 90, v = [0, 1, 0]) {\n\t\t\t\tcylinder(center = true, h = 20, r = 2);\n\t\t\t}\n\t\t}\n\t} /* End Holes */ \n}'
+        expected = '\n\ndifference() {\n\tunion() {\n\t\tunion() {\n\t\t\tcube(center = true, size = 10);\n\t\t}\n\t\trotate(a = -90, v = [0, 1, 0]) {\n\t\t}\n\t}\n\t/* Holes Below*/\n\tunion() {\n\t\tunion() {\n\t\t\trotate(a = 90, v = [0, 1, 0]) {\n\t\t\t\tcylinder(center = true, h = 20, r = 2);\n\t\t\t}\n\t\t}\n\t\trotate(a = -90, v = [0, 1, 0]) {\n\t\t\trotate(a = 90, v = [0, 1, 0]) {\n\t\t\t\tcylinder(center = true, h = 20, r = 2);\n\t\t\t}\n\t\t}\n\t} /* End Holes */ \n}'
         actual = scad_render(a)
         self.assertEqual(expected, actual)
 
@@ -220,7 +219,7 @@ class TestSolidPython(DiffOutput):
 
         a = p1 + p2
 
-        expected = '\n\nunion() {\n\tdifference(){\n\t\tdifference() {\n\t\t\tcube(center = true, size = 10);\n\t\t}\n\t\t/* Holes Below*/\n\t\tdifference(){\n\t\t\tcylinder(center = true, h = 12, r = 2);\n\t\t} /* End Holes */ \n\t}\n\tcylinder(center = true, h = 14, r = 1.5000000000);\n}'
+        expected = '\n\nunion() {\n\tdifference() {\n\t\tdifference() {\n\t\t\tcube(center = true, size = 10);\n\t\t}\n\t\t/* Holes Below*/\n\t\tdifference() {\n\t\t\tcylinder(center = true, h = 12, r = 2);\n\t\t} /* End Holes */ \n\t}\n\tcylinder(center = true, h = 14, r = 1.5000000000);\n}'
         actual = scad_render(a)
         self.assertEqual(expected, actual)
 
@@ -237,7 +236,7 @@ class TestSolidPython(DiffOutput):
                                       filepath=tmp.name, include_orig_code=False)
 
         actual = tmp.contents
-        expected = '\nif ($t >= 0.0 && $t < 0.5){   \n\ttranslate(v = [15.0000000000, 0.0000000000]) {\n\t\tsquare(size = 10);\n\t}\n}\nif ($t >= 0.5 && $t < 1.0){   \n\ttranslate(v = [-15.0000000000, 0.0000000000]) {\n\t\tsquare(size = 10);\n\t}\n}\n'
+        expected = '\nif ($t >= 0.0 && $t < 0.5) {   \n\ttranslate(v = [15.0000000000, 0.0000000000]) {\n\t\tsquare(size = 10);\n\t}\n}\nif ($t >= 0.5 && $t < 1.0) {   \n\ttranslate(v = [-15.0000000000, 0.0000000000]) {\n\t\tsquare(size = 10);\n\t}\n}\n'
 
         self.assertEqual(expected, actual)
 

--- a/solid/test/test_solidpython.py
+++ b/solid/test/test_solidpython.py
@@ -194,7 +194,7 @@ class TestSolidPython(DiffOutput):
         )
 
         a = cube(10, center=True) + h + h_vert
-        expected = '\n\ndifference() {\n\tunion() {\n\t\tunion() {\n\t\t\tcube(center = true, size = 10);\n\t\t}\n\t\trotate(a = -90, v = [0, 1, 0]) {\n\t\t}\n\t}\n\t/* Holes Below*/\n\tunion() {\n\t\tunion() {\n\t\t\trotate(a = 90, v = [0, 1, 0]) {\n\t\t\t\tcylinder(center = true, h = 20, r = 2);\n\t\t\t}\n\t\t}\n\t\trotate(a = -90, v = [0, 1, 0]) {\n\t\t\trotate(a = 90, v = [0, 1, 0]) {\n\t\t\t\tcylinder(center = true, h = 20, r = 2);\n\t\t\t}\n\t\t}\n\t} /* End Holes */ \n}'
+        expected = '\n\ndifference() {\n\tunion() {\n\t\tcube(center = true, size = 10);\n\t\trotate(a = -90, v = [0, 1, 0]) {\n\t\t}\n\t}\n\t/* Holes Below*/\n\tunion() {\n\t\trotate(a = 90, v = [0, 1, 0]) {\n\t\t\tcylinder(center = true, h = 20, r = 2);\n\t\t}\n\t\trotate(a = -90, v = [0, 1, 0]) {\n\t\t\trotate(a = 90, v = [0, 1, 0]) {\n\t\t\t\tcylinder(center = true, h = 20, r = 2);\n\t\t\t}\n\t\t}\n\t} /* End Holes */ \n}'
         actual = scad_render(a)
         self.assertEqual(expected, actual)
 

--- a/solid/test/test_utils.py
+++ b/solid/test/test_utils.py
@@ -15,12 +15,12 @@ from solid.test.ExpandedTestCase import DiffOutput
 
 tri = [Point3(0, 0, 0), Point3(10, 0, 0), Point3(0, 10, 0)]
 scad_test_cases = [
-    (                               up,                 [2],   '\n\ntranslate(v = [0, 0, 2]);'),
-    (                               down,               [2],   '\n\ntranslate(v = [0, 0, -2]);'),
-    (                               left,               [2],   '\n\ntranslate(v = [-2, 0, 0]);'),
-    (                               right,              [2],   '\n\ntranslate(v = [2, 0, 0]);'),
-    (                               forward,            [2],   '\n\ntranslate(v = [0, 2, 0]);'),
-    (                               back,               [2],   '\n\ntranslate(v = [0, -2, 0]);'),   
+    (                               up,                 [2],   '\n\ntranslate(v = [0, 0, 2]) {\n}'),
+    (                               down,               [2],   '\n\ntranslate(v = [0, 0, -2]) {\n}'),
+    (                               left,               [2],   '\n\ntranslate(v = [-2, 0, 0]) {\n}'),
+    (                               right,              [2],   '\n\ntranslate(v = [2, 0, 0]) {\n}'),
+    (                               forward,            [2],   '\n\ntranslate(v = [0, 2, 0]) {\n}'),
+    (                               back,               [2],   '\n\ntranslate(v = [0, -2, 0]) {\n}'),   
     (                               arc,                [10, 0, 90, 24], '\n\ndifference() {\n\tcircle($fn = 24, r = 10);\n\trotate(a = 0) {\n\t\ttranslate(v = [0, -10, 0]) {\n\t\t\tsquare(center = true, size = [30, 20]);\n\t\t}\n\t}\n\trotate(a = -90) {\n\t\ttranslate(v = [0, -10, 0]) {\n\t\t\tsquare(center = true, size = [30, 20]);\n\t\t}\n\t}\n}'),
     (                               arc_inverted,       [10, 0, 90, 24], '\n\ndifference() {\n\tintersection() {\n\t\trotate(a = 0) {\n\t\t\ttranslate(v = [-990, 0]) {\n\t\t\t\tsquare(center = false, size = [1000, 1000]);\n\t\t\t}\n\t\t}\n\t\trotate(a = 90) {\n\t\t\ttranslate(v = [-990, -1000]) {\n\t\t\t\tsquare(center = false, size = [1000, 1000]);\n\t\t\t}\n\t\t}\n\t}\n\tcircle($fn = 24, r = 10);\n}'),
     ( 'transform_to_point_scad',    transform_to_point, [cube(2), [2,2,2], [3,3,1]], '\n\nmultmatrix(m = [[0.7071067812, -0.1622214211, -0.6882472016, 2], [-0.7071067812, -0.1622214211, -0.6882472016, 2], [0.0000000000, 0.9733285268, -0.2294157339, 2], [0, 0, 0, 1.0000000000]]) {\n\tcube(size = 2);\n}'),


### PR DESCRIPTION
restricts the ability to do  cube(3)(cube(2)) by subclassing the transformation objects and moving there the __call__ method previously present in OpenSCADObject

* while not a bug -this was legal and the code accepted by OpenScad- it was misleading since the second cube will never show