### PR TITLE
merged  operations for +-*

### DIFF
--- a/solid/objects.py
+++ b/solid/objects.py
@@ -168,6 +168,9 @@ class union(OpenSCADObject):
     def __init__(self):
         OpenSCADObject.__init__(self, 'union', {})
 
+    def __add__(self, x):
+        return self.add(x)
+
 
 class intersection(OpenSCADObject):
     '''
@@ -177,6 +180,9 @@ class intersection(OpenSCADObject):
     def __init__(self):
         OpenSCADObject.__init__(self, 'intersection', {})
 
+    def __mul__(self, x):
+        return self.add(x)
+
 
 class difference(OpenSCADObject):
     '''
@@ -184,6 +190,9 @@ class difference(OpenSCADObject):
     '''
     def __init__(self):
         OpenSCADObject.__init__(self, 'difference', {})
+
+    def __sub__(self,x):
+        return self.add(x)
 
 
 class hole(OpenSCADObject):


### PR DESCRIPTION
Consecutive sums/subtractions/multiplications are merged into the same transformation instead of nested as independent ones
eg: cube(1)+cube(2)+cube(3)

current, nested:
```
union() { 
	union() {
		cube(size = 1);
		cube(size = 2);
	}
	cube(size = 3);
}
```
proposed, merged:
```
union() {
	cube(size = 1);
	cube(size = 2);
	cube(size = 3);
}
```
While it do not seems to have any notable impact on the render time at OpenScad for the difference and intersection transforms it have a considerable impact for the unions: On the simple case below it cut the render time to a third, on other cases the nested code just hanged there for many minutes -till patience run out actually- while it took ~1min for the merged code to render

Simple test case, render time:
union :
```python
scene = cube(2)
for i in range(100):
    scene += translate([i,i,0])(cube(2))
```
OpenScad console output ...
* Nested:
```
    Compiling design (CSG Tree generation)...
    Rendering Polygon Mesh using CGAL...
    Geometries in cache: 101
    Geometry cache size in bytes: 73528
    CGAL Polyhedrons in cache: 101
    CGAL cache size in bytes: 55432592
    Total rendering time: 0 hours, 1 minutes, 3 seconds
       Top level object is a 3D object:
       Simple:        yes
       Vertices:      800
       Halfedges:    2400
       Edges:        1200
       Halffacets:    804
       Facets:        402
       Volumes:         2
    Rendering finished.
```
* Merged:
```
    Compiling design (CSG Tree generation)...
    Rendering Polygon Mesh using CGAL...
    Geometries in cache: 101
    Geometry cache size in bytes: 73528
    CGAL Polyhedrons in cache: 2
    CGAL cache size in bytes: 2151584
    Total rendering time: 0 hours, 0 minutes, 19 seconds
       Top level object is a 3D object:
       Simple:        yes
       Vertices:      800
       Halfedges:    2400
       Edges:        1200
       Halffacets:    804
       Facets:        402
       Volumes:         2
    Rendering finished.
```