### PR TITLE
Allow parts to store measurement (or other) data 

### DIFF
--- a/solid/objects.py
+++ b/solid/objects.py
@@ -203,7 +203,12 @@ class part(OpenSCADObject):
     - in effect holes created in the assembly can be filled by CSG operations with other objects. 
     The part stores extra information about parameters used to create the part. This allows 
     the object to be queried for the creation of, eg, mating parts.  For example, specifying an internal
-    screw thread might permit the on-the-fly calculation of a matching external thread. 
+    screw thread might permit the on-the-fly calculation of a matching external thread.
+    
+    [Once a part allows data storage and introspection, it will facilitate other uses - such as nominating 
+    part connectors, re-orienting parts to mate them together at specfied connectors, splitting out 
+    separate parts from an object and arranging them on a print bed for printing, in place rotation around
+    a nominated centre or rotation etc]
     
     Brendan Barnacle Duck, March 17
     """
@@ -235,7 +240,7 @@ class part(OpenSCADObject):
         if part_id is None:
             part_id = str(uuid.uuid4()) # random uuid
             
-        # dimension guessing
+        # if dimesions are not provided explicitly, try to deduce them from the calling function
         if dims_dict is None:
             # then try to grab them from what was provided to the calling function
             #  - ie the function that assembled this part. 
@@ -260,7 +265,7 @@ class part(OpenSCADObject):
                 # it's a number
                 spam = float(v)
                 args.append((k,v))
-            except ValueError:
+            except (ValueError, TypeError):
                 # its a string
                 args.append((k,"""'%s'"""%v))
                 

--- a/solid/solidpython.py
+++ b/solid/solidpython.py
@@ -8,7 +8,6 @@
 #   License: LGPL 2.1 or later
 #
 
-
 import os, sys, re
 import inspect
 import subprocess
@@ -570,6 +569,24 @@ class OpenSCADObject(object):
             os.unlink(tmp_png.name)
 
         return png_data
+
+    def get_part(self, part_id):
+        """ find child with id = part_id"""
+        if self.is_part_root:
+            if self.part_id == part_id:
+                return self
+        else:
+            for c in self.children:
+                p = c.get_part(part_id)
+                if p is not None:
+                    return p
+        return None
+
+    def get_part_dim(self, part_id,  dim_name):
+        """Find the value of var_name for part with id =  part_id
+        """
+        p = self.get_part(part_id)
+        return p.part_dims[dim_name]
 
 
 class IncludedOpenSCADObject(OpenSCADObject):

--- a/solid/test/test_solidpython.py
+++ b/solid/test/test_solidpython.py
@@ -7,6 +7,9 @@ import re
 import unittest
 import tempfile
 from solid.test.ExpandedTestCase import DiffOutput
+
+import os,sys,inspect
+
 from solid import *
 
 scad_test_case_templates = [
@@ -265,6 +268,40 @@ class TestSolidPython(DiffOutput):
 
         # TODO: test include_orig_code=True, but that would have to
         # be done from a separate file, or include everything in this one
+
+
+
+    def test_extended_part(self):        
+        # create part, __repr__ works as expected
+        part1 = make_a_part("part1")
+        actual = part1.__repr__()
+        expected = """make_a_part(partid='part1', width=20, length=40, depth=10)"""
+        self.assertEqual(expected, actual)
+        
+        test_sphere = sphere(1)
+        obj = union()(part1, test_sphere)
+        obj = translate([10,10,10])(obj)
+        obj = rotate([90,0,0])(obj)
+        
+        # get part correctly traverses object tree to find part1
+        part2 = obj.get_part("part1")
+        self.assertEqual(part1, part2)
+        
+        width = obj.get_part_dim("part1", "width")
+        self.assertEqual(width, 20)
+
+
+def make_a_part(partid, width=20,  length=40,  depth=10):
+    obj = cube([width,  length,  depth])
+
+    # additional locals that need to be not recorded in the part
+    half_width = width/2
+    half_length = length/2
+    half_depth = depth/2
+    obj = part(part_id="part1")(obj) 
+    
+    return obj
+
 
 
 def single_test(test_dict):


### PR DESCRIPTION
I have worked on the part class to allow it to record, eg, the dimensions used to create the part. This can be used to programmatically create mating or complementary parts. 
With further development it could support automation such as:
* orientation of parts by reference to connectors/normals.    
* splitting out sub-parts for printing.
* rotating the object to be on the xy plane 
* tracking an object's bounding box

The changes consist of modifications to the part class, as well as some methods in the base OpenSCADObject class to allow finding parts by id, finding dimensions of a nominated part. 

At the moment it assumes that a part is created in a separate function, and that that function's arguments correspond to the part's dimensions. 

