### PR TITLE
small fix for multiple subtracting holes

### DIFF
--- a/solid/solidpython.py
+++ b/solid/solidpython.py
@@ -534,7 +534,10 @@ class OpenSCADObject(object):
         This makes u = a - b identical to:
         u = difference()(a, b )
         '''
-        return objects.difference()(self, x)
+        if not x.is_hole:
+            return objects.difference()(self, x)
+        else:
+            return objects.union()(self, x)
 
     def __mul__(self, x):
         '''

--- a/solid/solidpython.py
+++ b/solid/solidpython.py
@@ -534,10 +534,13 @@ class OpenSCADObject(object):
         This makes u = a - b identical to:
         u = difference()(a, b )
         '''
-        if not x.is_hole:
-            return objects.difference()(self, x)
-        else:
-            return objects.union()(self, x)
+        if not isinstance(x,list):
+            x = [x]
+        for xi in x:
+            if not xi.is_hole:
+                return objects.difference()(self, xi)
+            else:
+                return objects.union()(self, xi)
 
     def __mul__(self, x):
         '''

--- a/solid/test/run_all_tests.sh
+++ b/solid/test/run_all_tests.sh
@@ -1,6 +1,6 @@
 # Note that this file needs to be run from solid/test.  
 for i in test_*.py;
-do 
+do
 echo $i;
 python $i;
 echo

--- a/solid/test/test_solidpython.py
+++ b/solid/test/test_solidpython.py
@@ -219,7 +219,7 @@ class TestSolidPython(DiffOutput):
 
         a = p1 + p2
 
-        expected = '\n\nunion() {\n\tdifference(){\n\t\tdifference() {\n\t\t\tcube(center = true, size = 10);\n\t\t}\n\t\t/* Holes Below*/\n\t\tdifference(){\n\t\t\tcylinder(center = true, h = 12, r = 2);\n\t\t} /* End Holes */ \n\t}\n\tcylinder(center = true, h = 14, r = 1.5000000000);\n}'
+        expected = '\n\nunion() {\n\tdifference(){\n\t\tunion() {\n\t\t\tcube(center = true, size = 10);\n\t\t}\n\t\t/* Holes Below*/\n\t\tunion(){\n\t\t\tcylinder(center = true, h = 12, r = 2);\n\t\t} /* End Holes */ \n\t}\n\tcylinder(center = true, h = 14, r = 1.5000000000);\n}'
         actual = scad_render(a)
         self.assertEqual(expected, actual)
 


### PR DESCRIPTION
When two or more holes are subtracted from a initial solid, only the first hole have any effect.
The proposed fix enforces that holes are added as unions and not as differences.

test code:
```
scene = ( cube([10,10,1],center=True)
	      - cylinder().set_hole()
          - translate([3,0,0])(cylinder()).set_hole()
        )
scad_render_to_file(scene, 'preview.scad', '$fs=.75;')
```
The current render will show a single hole since the second hole is subtracted from the first and they do not overlap:
```
difference(){
	difference() {
		difference() {
			cube(center = true, size = [10, 10, 1]);
		}
	}
	/* Holes Below*/
	difference(){
		difference(){
			cylinder();
		}
		translate(v = [3, 0, 0]) {
			cylinder();
		}
	} /* End Holes */ 
}
```

The render with the proposed fix will show the two holes as expected:
```
difference(){
	union() {
		union() {
			cube(center = true, size = [10, 10, 1]);
		}
	}
	/* Holes Below*/
	union(){
		union(){
			cylinder();
		}
		translate(v = [3, 0, 0]) {
			cylinder();
		}
	} /* End Holes */ 
}
```

Only elements labeled as holes are forced as unions, this will not affect the inner structure of the holes objects, so if the hole solid is created using a difference this will be kept.
The next will work as expected, where the third hole will be a 3/4 of cylinder shape:
```
scene = ( cube([10,10,1],center=True)
          - cylinder().set_hole()
          - translate([3,0,0])(cylinder()).set_hole()
          - translate([-3,0,0])(cylinder()-cube()).set_hole()
        )
```
