### PR TITLE
Update solidpython.py

### DIFF
--- a/solid/solidpython.py
+++ b/solid/solidpython.py
@@ -432,31 +432,33 @@ class OpenSCADObject(object):
             if child.is_hole:
                 s += child._render(render_holes=True)
             elif child.has_hole_children:
-                # Holes exist in the compiled tree in two pieces:
-                # The shapes of the holes themselves, (an object for which
-                # obj.is_hole is True, and all its children) and the
-                # transforms necessary to put that hole in place, which
-                # are inherited from non-hole geometry.
-
-                # Non-hole Intersections & differences can change (shrink)
-                # the size of holes, and that shouldn't happen: an
-                # intersection/difference with an empty space should be the
-                # entirety of the empty space.
-                #  In fact, the intersection of two empty spaces should be
-                # everything contained in both of them:  their union.
-                # So... replace all super-hole intersection/diff transforms
-                # with union in the hole segment of the compiled tree.
-                # And if you figure out a better way to explain this,
-                # please, please do... because I think this works, but I
-                # also think my rationale is shaky and imprecise. 
-                # -ETJ 19 Feb 2013
-                s = s.replace("intersection", "union")
-                s = s.replace("difference", "union")
                 s += child._render_hole_children()
         if self.name in non_rendered_classes:
             pass
         else:
             s = self._render_str_no_children() + "{" + indent(s) + "\n}"
+            
+        # Holes exist in the compiled tree in two pieces:
+        # The shapes of the holes themselves, (an object for which
+        # obj.is_hole is True, and all its children) and the
+        # transforms necessary to put that hole in place, which
+        # are inherited from non-hole geometry.
+
+        # Non-hole Intersections & differences can change (shrink)
+        # the size of holes, and that shouldn't happen: an
+        # intersection/difference with an empty space should be the
+        # entirety of the empty space.
+        #  In fact, the intersection of two empty spaces should be
+        # everything contained in both of them:  their union.
+        # So... replace all super-hole intersection/diff transforms
+        # with union in the hole segment of the compiled tree.
+        # And if you figure out a better way to explain this,
+        # please, please do... because I think this works, but I
+        # also think my rationale is shaky and imprecise. 
+        # -ETJ 19 Feb 2013
+        s = s.replace("intersection", "union")
+        s = s.replace("difference", "union")
+            
         return s
 
     def add(self, child):

--- a/solid/test/test_solidpython.py
+++ b/solid/test/test_solidpython.py
@@ -220,7 +220,7 @@ class TestSolidPython(DiffOutput):
 
         a = p1 + p2
 
-        expected = '\n\nunion() {\n\tdifference(){\n\t\tdifference() {\n\t\t\tcube(center = true, size = 10);\n\t\t}\n\t\t/* Holes Below*/\n\t\tdifference(){\n\t\t\tcylinder(center = true, h = 12, r = 2);\n\t\t} /* End Holes */ \n\t}\n\tcylinder(center = true, h = 14, r = 1.5000000000);\n}'
+        expected = '\n\nunion() {\n\tdifference(){\n\t\tdifference() {\n\t\t\tcube(center = true, size = 10);\n\t\t}\n\t\t/* Holes Below*/\n\t\tunion(){\n\t\t\tcylinder(center = true, h = 12, r = 2);\n\t\t} /* End Holes */ \n\t}\n\tcylinder(center = true, h = 14, r = 1.5000000000);\n}'
         actual = scad_render(a)
         self.assertEqual(expected, actual)
 


### PR DESCRIPTION
@scifuentes pointed out a bug in how holes work in #73, but I think I found the source of the problem.  I'd already taken into account that holes shouldn't be able to grow smaller by subtracting one from another, but the substitution that required (`difference` & `intersection` => `union`) wasn't being universally applied.  Moved that big comment and the substitutions to the very end of `_render_hole_children()`