### PR TITLE
Add "angle" parameter to rotate_extrude()

### DIFF
--- a/solid/objects.py
+++ b/solid/objects.py
@@ -403,18 +403,18 @@ class rotate_extrude(OpenSCADObject):
 
     :param angle: Defaults to 360. Specifies the number of degrees to sweep, starting at the positive X axis. The direction of the sweep follows the Right Hand Rule, hence a negative angle will sweep clockwise.
     :type angle: number
+    
+    :param segments: The fixed number of fragments to use.
+    :type segments: int
 
     :param convexity: The convexity parameter specifies the maximum number of front sides (back sides) a ray intersecting the object might penetrate. This parameter is only needed for correctly displaying the object in OpenCSG preview mode and has no effect on the polyhedron rendering.
     :type convexity: int
 
-    :param segments: The fixed number of fragments to use.
-    :type segments: int
-
     '''
     def __init__(self, angle=360, convexity=None, segments=None):
         OpenSCADObject.__init__(self, 'rotate_extrude',
-                                {'angle': angle, 'convexity': convexity,
-                                 'segments': segments})
+                                {'angle': angle, 'segments': segments, 
+                                 'convexity': convexity})
 
 
 class dxf_linear_extrude(OpenSCADObject):

--- a/solid/objects.py
+++ b/solid/objects.py
@@ -401,6 +401,9 @@ class rotate_extrude(OpenSCADObject):
     is in the negative axis the faces will be inside-out, you probably don't
     want to do that; it may be fixed in the future.
 
+    :param angle: Defaults to 360. Specifies the number of degrees to sweep, starting at the positive X axis. The direction of the sweep follows the Right Hand Rule, hence a negative angle will sweep clockwise.
+    :type angle: number
+
     :param convexity: The convexity parameter specifies the maximum number of front sides (back sides) a ray intersecting the object might penetrate. This parameter is only needed for correctly displaying the object in OpenCSG preview mode and has no effect on the polyhedron rendering.
     :type convexity: int
 
@@ -408,9 +411,10 @@ class rotate_extrude(OpenSCADObject):
     :type segments: int
 
     '''
-    def __init__(self, convexity=None, segments=None):
+    def __init__(self, angle=360, convexity=None, segments=None):
         OpenSCADObject.__init__(self, 'rotate_extrude',
-                                {'convexity': convexity, 'segments': segments})
+                                {'angle': angle, 'convexity': convexity,
+                                 'segments': segments})
 
 
 class dxf_linear_extrude(OpenSCADObject):


### PR DESCRIPTION
The `angle` parameter is present in openscad versions after 2016.xx. See https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/2D_to_3D_Extrusion#Rotate_Extrude.

Note: I added the new parameter as the last argument to the function for backwards-compatibility reasons, but maybe it would make more sense to put it before the `segments` param. Thoughts?