### PR TITLE
added threshold to numpy array2string()

### DIFF
--- a/solid/solidpython.py
+++ b/solid/solidpython.py
@@ -682,7 +682,7 @@ def py2openscad(o):
         return '"' + o + '"'
     if type(o).__name__ == "ndarray":
         import numpy
-        return numpy.array2string(o, separator=",")
+        return numpy.array2string(o, separator=",", threshold=1000000000)
     return str(o)
 
 


### PR DESCRIPTION
I ran into trouble when I generated openscad code from a large Polyhedron object which had many vertices contained in a numpy array.  It turns out that the ndarray.array2string() method that SolidPython was using truncates the string output at some arbitrary point by default.  I just added a parameter to the array2string() call to increase this limit to a large value.