### PR TITLE
Add support for using custom iterables as parameters

### DIFF
--- a/solid/solidpython.py
+++ b/solid/solidpython.py
@@ -668,7 +668,12 @@ def py2openscad(o):
         return str(o).lower()
     if type(o) == float:
         return "%.10f" % o
-    if type(o) == list or type(o) == tuple:
+    if type(o) == str:
+        return '"' + o + '"'
+    if type(o).__name__ == "ndarray":
+        import numpy
+        return numpy.array2string(o, separator=",", threshold=1000000000)
+    if hasattr(o, "__iter__"):
         s = "["
         first = True
         for i in o:
@@ -678,11 +683,6 @@ def py2openscad(o):
             s += py2openscad(i)
         s += "]"
         return s
-    if type(o) == str:
-        return '"' + o + '"'
-    if type(o).__name__ == "ndarray":
-        import numpy
-        return numpy.array2string(o, separator=",", threshold=1000000000)
     return str(o)
 
 

--- a/solid/test/test_solidpython.py
+++ b/solid/test/test_solidpython.py
@@ -347,7 +347,27 @@ class TestSolidPython(DiffOutput):
         except ImportError:
             pass
 
-            
+    def test_custom_iterables(self):
+        from euclid3 import Vector3
+
+        class CustomIterable:
+            def __iter__(self):
+                return iter([1, 2, 3])
+
+        expected ='\n\ncube(size = [1, 2, 3]);'
+        iterables = [
+            [1, 2, 3],
+            (1, 2, 3),
+            Vector3(1, 2, 3),
+            CustomIterable(),
+        ]
+
+        for iterable in iterables:
+            name = type(iterable).__name__
+            actual = scad_render(cube(size=iterable))
+            self.assertEqual(expected, actual, '%s SolidPython not rendered correctly' % name)
+
+
 def single_test(test_dict):
     name, args, kwargs, expected = test_dict['name'], test_dict['args'], test_dict['kwargs'], test_dict['expected']
 


### PR DESCRIPTION
This pull request adjusts the way SolidPython converts Python parameters into OpenSCAD parameters by converting any iterable object into a vector, not just list, tuples, and numpy ndarrays.

This means it's now possible to write Python code that looks like this:

    from euclid3 import Vector3
    from solidpython import *

    model = cube(size=Vector3(1, 2, 3))
    scad_render_to_file(model, 'cube.scad')

This program previously used to generate invalid OpenSCAD code -- the `py2openscad(...)` would fall back to calling `str(...)` on the Vector3, producing `cube(size = Vector3(1, 2, 3))` as output.