### PR TITLE
Pep8 objects

### DIFF
--- a/solid/objects.py
+++ b/solid/objects.py
@@ -41,8 +41,8 @@ class polygon(OpenSCADObject):
     def __init__(self, points: Points, paths: Indexes = None):
         if not paths:
             paths = [list(range(len(points)))]
-        OpenSCADObject.__init__(self, 'polygon',
-                                {'points': points, 'paths': paths})
+        super().__init__('polygon',
+                         {'points': points, 'paths': paths})
 
 
 class circle(OpenSCADObject):
@@ -61,8 +61,8 @@ class circle(OpenSCADObject):
     """
 
     def __init__(self, r: float = None, d: float = None, segments: int = None):
-        OpenSCADObject.__init__(self, 'circle',
-                                {'r': r, 'd': d, 'segments': segments})
+        super().__init__('circle',
+                         {'r': r, 'd': d, 'segments': segments})
 
 
 class square(OpenSCADObject):
@@ -84,8 +84,8 @@ class square(OpenSCADObject):
     """
 
     def __init__(self, size: ScadSize = None, center: bool = None):
-        OpenSCADObject.__init__(self, 'square',
-                                {'size': size, 'center': center})
+        super().__init__('square',
+                         {'size': size, 'center': center})
 
 
 class sphere(OpenSCADObject):
@@ -104,8 +104,8 @@ class sphere(OpenSCADObject):
     """
 
     def __init__(self, r: float = None, d: float = None, segments: int = None):
-        OpenSCADObject.__init__(self, 'sphere',
-                                {'r': r, 'd': d, 'segments': segments})
+        super().__init__('sphere',
+                         {'r': r, 'd': d, 'segments': segments})
 
 
 class cube(OpenSCADObject):
@@ -127,8 +127,8 @@ class cube(OpenSCADObject):
     """
 
     def __init__(self, size: ScadSize = None, center: bool = None):
-        OpenSCADObject.__init__(self, 'cube',
-                                {'size': size, 'center': center})
+        super().__init__('cube',
+                         {'size': size, 'center': center})
 
 
 class cylinder(OpenSCADObject):
@@ -172,10 +172,10 @@ class cylinder(OpenSCADObject):
     def __init__(self, r: float = None, h: float = None, r1: float = None, r2: float = None,
                  d: float = None, d1: float = None, d2: float = None, center: bool = None,
                  segments: int = None):
-        OpenSCADObject.__init__(self, 'cylinder',
-                                {'r': r, 'h': h, 'r1': r1, 'r2': r2, 'd': d,
-                                 'd1': d1, 'd2': d2, 'center': center,
-                                 'segments': segments})
+        super().__init__('cylinder',
+                         {'r': r, 'h': h, 'r1': r1, 'r2': r2, 'd': d,
+                          'd1': d1, 'd2': d2, 'center': center,
+                          'segments': segments})
 
 
 class polyhedron(OpenSCADObject):
@@ -207,10 +207,10 @@ class polyhedron(OpenSCADObject):
     """
 
     def __init__(self, points: P3s, faces: Indexes, convexity: int = None, triangles: Indexes = None):
-        OpenSCADObject.__init__(self, 'polyhedron',
-                                {'points': points, 'faces': faces,
-                                 'convexity': convexity,
-                                 'triangles': triangles})
+        super().__init__('polyhedron',
+                         {'points': points, 'faces': faces,
+                          'convexity': convexity,
+                          'triangles': triangles})
 
 
 class union(OpenSCADObject):
@@ -220,7 +220,7 @@ class union(OpenSCADObject):
     """
 
     def __init__(self):
-        OpenSCADObject.__init__(self, 'union', {})
+        super().__init__('union', {})
 
     def __add__(self, x: OpenSCADObjectPlus) -> OpenSCADObject:
         new_union = union()
@@ -238,7 +238,7 @@ class intersection(OpenSCADObject):
     """
 
     def __init__(self):
-        OpenSCADObject.__init__(self, 'intersection', {})
+        super().__init__('intersection', {})
 
     def __mul__(self, x: OpenSCADObjectPlus) -> OpenSCADObject:
         new_int = intersection()
@@ -255,7 +255,7 @@ class difference(OpenSCADObject):
     """
 
     def __init__(self):
-        OpenSCADObject.__init__(self, 'difference', {})
+        super().__init__('difference', {})
 
     def __sub__(self, x: OpenSCADObjectPlus) -> OpenSCADObject:
         new_diff = difference()
@@ -268,13 +268,13 @@ class difference(OpenSCADObject):
 
 class hole(OpenSCADObject):
     def __init__(self):
-        OpenSCADObject.__init__(self, 'hole', {})
+        super().__init__('hole', {})
         self.set_hole(True)
 
 
 class part(OpenSCADObject):
     def __init__(self):
-        OpenSCADObject.__init__(self, 'part', {})
+        super().__init__('part', {})
         self.set_part_root(True)
 
 
@@ -287,7 +287,7 @@ class translate(OpenSCADObject):
     """
 
     def __init__(self, v: P3 = None):
-        OpenSCADObject.__init__(self, 'translate', {'v': v})
+        super().__init__('translate', {'v': v})
 
 
 class scale(OpenSCADObject):
@@ -299,7 +299,7 @@ class scale(OpenSCADObject):
     """
 
     def __init__(self, v: P3 = None):
-        OpenSCADObject.__init__(self, 'scale', {'v': v})
+        super().__init__('scale', {'v': v})
 
 
 class rotate(OpenSCADObject):
@@ -315,7 +315,7 @@ class rotate(OpenSCADObject):
     """
 
     def __init__(self, a: Union[float, Vec3] = None, v: Vec3 = None):
-        OpenSCADObject.__init__(self, 'rotate', {'a': a, 'v': v})
+        super().__init__('rotate', {'a': a, 'v': v})
 
 
 class mirror(OpenSCADObject):
@@ -328,7 +328,7 @@ class mirror(OpenSCADObject):
     """
 
     def __init__(self, v: Vec3):
-        OpenSCADObject.__init__(self, 'mirror', {'v': v})
+        super().__init__('mirror', {'v': v})
 
 
 class resize(OpenSCADObject):
@@ -343,7 +343,7 @@ class resize(OpenSCADObject):
     """
 
     def __init__(self, newsize: Vec3, auto: Tuple[bool, bool, bool] = None):
-        OpenSCADObject.__init__(self, 'resize', {'newsize': newsize, 'auto': auto})
+        super().__init__('resize', {'newsize': newsize, 'auto': auto})
 
 
 class multmatrix(OpenSCADObject):
@@ -356,7 +356,7 @@ class multmatrix(OpenSCADObject):
     """
 
     def __init__(self, m: Tuple[Vec4, Vec4, Vec4, Vec4]):
-        OpenSCADObject.__init__(self, 'multmatrix', {'m': m})
+        super().__init__('multmatrix', {'m': m})
 
 
 class color(OpenSCADObject):
@@ -371,7 +371,7 @@ class color(OpenSCADObject):
     """
 
     def __init__(self, c: Vec34):
-        OpenSCADObject.__init__(self, 'color', {'c': c})
+        super().__init__('color', {'c': c})
 
 
 class minkowski(OpenSCADObject):
@@ -382,7 +382,7 @@ class minkowski(OpenSCADObject):
     """
 
     def __init__(self):
-        OpenSCADObject.__init__(self, 'minkowski', {})
+        super().__init__('minkowski', {})
 
 
 class offset(OpenSCADObject):
@@ -411,7 +411,7 @@ class offset(OpenSCADObject):
             kwargs = {'delta': delta, 'chamfer': chamfer}
         else:
             raise ValueError("offset(): Must supply r or delta")
-        OpenSCADObject.__init__(self, 'offset', kwargs)
+        super().__init__('offset', kwargs)
 
 
 class hull(OpenSCADObject):
@@ -422,7 +422,7 @@ class hull(OpenSCADObject):
     """
 
     def __init__(self):
-        OpenSCADObject.__init__(self, 'hull', {})
+        super().__init__('hull', {})
 
 
 class render(OpenSCADObject):
@@ -435,7 +435,7 @@ class render(OpenSCADObject):
     """
 
     def __init__(self, convexity: int = None):
-        OpenSCADObject.__init__(self, 'render', {'convexity': convexity})
+        super().__init__('render', {'convexity': convexity})
 
 
 class linear_extrude(OpenSCADObject):
@@ -471,10 +471,10 @@ class linear_extrude(OpenSCADObject):
 
     def __init__(self, height: float = None, center: bool = None, convexity: int = None,
                  twist: float = None, slices: int = None, scale: float = None):
-        OpenSCADObject.__init__(self, 'linear_extrude',
-                                {'height': height, 'center': center,
-                                 'convexity': convexity, 'twist': twist,
-                                 'slices': slices, 'scale': scale})
+        super().__init__('linear_extrude',
+                         {'height': height, 'center': center,
+                          'convexity': convexity, 'twist': twist,
+                          'slices': slices, 'scale': scale})
 
 
 class rotate_extrude(OpenSCADObject):
@@ -508,20 +508,20 @@ class rotate_extrude(OpenSCADObject):
     """
 
     def __init__(self, angle: float = 360, convexity: int = None, segments: int = None):
-        OpenSCADObject.__init__(self, 'rotate_extrude',
-                                {'angle': angle, 'segments': segments,
-                                 'convexity': convexity})
+        super().__init__('rotate_extrude',
+                         {'angle': angle, 'segments': segments,
+                          'convexity': convexity})
 
 
 class dxf_linear_extrude(OpenSCADObject):
     def __init__(self, file: str, layer: float = None, height: float = None,
                  center: bool = None, convexity: int = None, twist: float = None,
                  slices: int = None):
-        OpenSCADObject.__init__(self, 'dxf_linear_extrude',
-                                {'file': file, 'layer': layer,
-                                 'height': height, 'center': center,
-                                 'convexity': convexity, 'twist': twist,
-                                 'slices': slices})
+        super().__init__('dxf_linear_extrude',
+                         {'file': file, 'layer': layer,
+                          'height': height, 'center': center,
+                          'convexity': convexity, 'twist': twist,
+                          'slices': slices})
 
 
 class projection(OpenSCADObject):
@@ -536,7 +536,7 @@ class projection(OpenSCADObject):
     """
 
     def __init__(self, cut: bool = None):
-        OpenSCADObject.__init__(self, 'projection', {'cut': cut})
+        super().__init__('projection', {'cut': cut})
 
 
 class surface(OpenSCADObject):
@@ -564,9 +564,9 @@ class surface(OpenSCADObject):
     """
 
     def __init__(self, file, center: bool = None, convexity: int = None, invert=None):
-        OpenSCADObject.__init__(self, 'surface',
-                                {'file': file, 'center': center,
-                                 'convexity': convexity, 'invert': invert})
+        super().__init__('surface',
+                         {'file': file, 'center': center,
+                          'convexity': convexity, 'invert': invert})
 
 
 class text(OpenSCADObject):
@@ -621,19 +621,19 @@ class text(OpenSCADObject):
     def __init__(self, text: str, size: float = None, font: str = None, halign: str = None,
                  valign: str = None, spacing: float = None, direction: str = None,
                  language: str = None, script: str = None, segments: int = None):
-        OpenSCADObject.__init__(self, 'text',
-                                {'text': text, 'size': size, 'font': font,
-                                 'halign': halign, 'valign': valign,
-                                 'spacing': spacing, 'direction': direction,
-                                 'language': language, 'script': script,
-                                 'segments': segments})
+        super().__init__('text',
+                         {'text': text, 'size': size, 'font': font,
+                          'halign': halign, 'valign': valign,
+                          'spacing': spacing, 'direction': direction,
+                          'language': language, 'script': script,
+                          'segments': segments})
 
 
 class child(OpenSCADObject):
     def __init__(self, index: int = None, vector: Sequence[int] = None, range=None):
-        OpenSCADObject.__init__(self, 'child',
-                                {'index': index, 'vector': vector,
-                                 'range': range})
+        super().__init__('child',
+                         {'index': index, 'vector': vector,
+                          'range': range})
 
 
 class children(OpenSCADObject):
@@ -654,23 +654,23 @@ class children(OpenSCADObject):
     """
 
     def __init__(self, index: int = None, vector: float = None, range: P23 = None):
-        OpenSCADObject.__init__(self, 'children',
-                                {'index': index, 'vector': vector,
-                                 'range': range})
+        super().__init__('children',
+                         {'index': index, 'vector': vector,
+                          'range': range})
 
 
 class import_stl(OpenSCADObject):
     def __init__(self, file: str, origin: P2 = (0, 0), convexity: int = None, layer: int = None):
-        OpenSCADObject.__init__(self, 'import',
-                                {'file': file, 'origin': origin,
-                                 'convexity': convexity, 'layer': layer})
+        super().__init__('import',
+                         {'file': file, 'origin': origin,
+                          'convexity': convexity, 'layer': layer})
 
 
 class import_dxf(OpenSCADObject):
     def __init__(self, file, origin=(0, 0), convexity: int = None, layer: int = None):
-        OpenSCADObject.__init__(self, 'import',
-                                {'file': file, 'origin': origin,
-                                 'convexity': convexity, 'layer': layer})
+        super().__init__('import',
+                         {'file': file, 'origin': origin,
+                          'convexity': convexity, 'layer': layer})
 
 
 class import_(OpenSCADObject):
@@ -689,9 +689,9 @@ class import_(OpenSCADObject):
     """
 
     def __init__(self, file: str, origin: P2 = (0, 0), convexity: int = None, layer: int = None):
-        OpenSCADObject.__init__(self, 'import',
-                                {'file': file, 'origin': origin,
-                                 'convexity': convexity, 'layer': layer})
+        super().__init__('import',
+                         {'file': file, 'origin': origin,
+                          'convexity': convexity, 'layer': layer})
 
 
 class intersection_for(OpenSCADObject):
@@ -701,12 +701,12 @@ class intersection_for(OpenSCADObject):
     """
 
     def __init__(self, n: int):
-        OpenSCADObject.__init__(self, 'intersection_for', {'n': n})
+        super().__init__('intersection_for', {'n': n})
 
 
 class assign(OpenSCADObject):
     def __init__(self):
-        OpenSCADObject.__init__(self, 'assign', {})
+        super().__init__('assign', {})
 
 
 # ================================

--- a/solid/objects.py
+++ b/solid/objects.py
@@ -792,7 +792,6 @@ def use(scad_file_path: PathStr, use_not_include: bool = True, dest_namespace_di
     """
     # These functions in solidpython are used here and only here; don't pollute
     # the global namespace with them
-    from pathlib import Path
     from .solidpython import parse_scad_callables
     from .solidpython import new_openscad_class_str
     from .solidpython import calling_module

--- a/solid/objects.py
+++ b/solid/objects.py
@@ -22,6 +22,7 @@ Indexes = Union[Sequence[int], Sequence[Sequence[int]]]
 ScadSize = Union[int, Sequence[float]]
 OpenSCADObjectPlus = Union[OpenSCADObject, Sequence[OpenSCADObject]]
 
+
 class polygon(OpenSCADObject):
     '''
     Create a polygon with the specified points and paths.
@@ -36,11 +37,13 @@ class polygon(OpenSCADObject):
     assumed in order. (The 'pN' components of the *paths* vector are 0-indexed 
     references to the elements of the *points* vector.)
     '''
-    def __init__(self, points:Points, paths:Indexes=None):
+
+    def __init__(self, points: Points, paths: Indexes = None):
         if not paths:
             paths = [list(range(len(points)))]
         OpenSCADObject.__init__(self, 'polygon',
                                 {'points': points, 'paths': paths})
+
 
 class circle(OpenSCADObject):
     '''
@@ -56,9 +59,11 @@ class circle(OpenSCADObject):
     :param segments: Number of fragments in 360 degrees.
     :type segments: int
     '''
-    def __init__(self, r:float=None, d:float=None, segments:int=None):
+
+    def __init__(self, r: float = None, d: float = None, segments: int = None):
         OpenSCADObject.__init__(self, 'circle',
                                 {'r': r, 'd': d, 'segments': segments})
+
 
 class square(OpenSCADObject):
     '''
@@ -77,9 +82,11 @@ class square(OpenSCADObject):
     quadrant with one corner at (0,0). Defaults to False.
     :type center: boolean
     '''
-    def __init__(self, size:ScadSize = None, center:bool = None):
+
+    def __init__(self, size: ScadSize = None, center: bool = None):
         OpenSCADObject.__init__(self, 'square',
                                 {'size': size, 'center': center})
+
 
 class sphere(OpenSCADObject):
     '''
@@ -95,9 +102,11 @@ class sphere(OpenSCADObject):
     :param segments: Resolution of the sphere
     :type segments: int
     '''
-    def __init__(self, r:float = None, d:float=None, segments:int=None):
+
+    def __init__(self, r: float = None, d: float = None, segments: int = None):
         OpenSCADObject.__init__(self, 'sphere',
                                 {'r': r, 'd': d, 'segments': segments})
+
 
 class cube(OpenSCADObject):
     '''
@@ -116,9 +125,11 @@ class cube(OpenSCADObject):
     quadrant with one corner at (0,0,0). Defaults to False
     :type center: boolean
     '''
-    def __init__(self, size:ScadSize = None, center:bool = None):
+
+    def __init__(self, size: ScadSize = None, center: bool = None):
         OpenSCADObject.__init__(self, 'cube',
                                 {'size': size, 'center': center})
+
 
 class cylinder(OpenSCADObject):
     '''
@@ -157,13 +168,15 @@ class cylinder(OpenSCADObject):
     :param segments: Number of fragments in 360 degrees.
     :type segments: int
     '''
-    def __init__(self, r:float = None, h:float=None, r1:float=None, r2:float=None, 
-                 d:float=None, d1:float=None, d2:float=None, center:bool = None, 
-                 segments:int=None):
+
+    def __init__(self, r: float = None, h: float = None, r1: float = None, r2: float = None,
+                 d: float = None, d1: float = None, d2: float = None, center: bool = None,
+                 segments: int = None):
         OpenSCADObject.__init__(self, 'cylinder',
                                 {'r': r, 'h': h, 'r1': r1, 'r2': r2, 'd': d,
                                  'd1': d1, 'd2': d2, 'center': center,
                                  'segments': segments})
+
 
 class polyhedron(OpenSCADObject):
     '''
@@ -192,68 +205,78 @@ class polyhedron(OpenSCADObject):
     preview mode and has no effect on the polyhedron rendering.
     :type convexity: int
     '''
-    def __init__(self, points:P3s, faces:Indexes, convexity:int=None, triangles:Indexes=None):
+
+    def __init__(self, points: P3s, faces: Indexes, convexity: int = None, triangles: Indexes = None):
         OpenSCADObject.__init__(self, 'polyhedron',
                                 {'points': points, 'faces': faces,
                                  'convexity': convexity,
                                  'triangles': triangles})
+
 
 class union(OpenSCADObject):
     '''
     Creates a union of all its child nodes. This is the **sum** of all
     children.
     '''
+
     def __init__(self):
         OpenSCADObject.__init__(self, 'union', {})
 
-    def __add__(self, x:OpenSCADObjectPlus) -> OpenSCADObject:
+    def __add__(self, x: OpenSCADObjectPlus) -> OpenSCADObject:
         new_union = union()
         for child in self.children:
             new_union.add(child)
         new_union.add(x)
-        
+
         return new_union
+
 
 class intersection(OpenSCADObject):
     '''
     Creates the intersection of all child nodes. This keeps the
     **overlapping** portion
     '''
+
     def __init__(self):
         OpenSCADObject.__init__(self, 'intersection', {})
 
-    def __mul__(self, x:OpenSCADObjectPlus) -> OpenSCADObject:
+    def __mul__(self, x: OpenSCADObjectPlus) -> OpenSCADObject:
         new_int = intersection()
         for child in self.children:
             new_int.add(child)
         new_int.add(x)
-        
+
         return new_int
+
 
 class difference(OpenSCADObject):
     '''
     Subtracts the 2nd (and all further) child nodes from the first one.
     '''
+
     def __init__(self):
         OpenSCADObject.__init__(self, 'difference', {})
 
-    def __sub__(self,x:OpenSCADObjectPlus) -> OpenSCADObject:
+    def __sub__(self, x: OpenSCADObjectPlus) -> OpenSCADObject:
         new_diff = difference()
         for child in self.children:
             new_diff.add(child)
         new_diff.add(x)
-        
+
         return new_diff
+
 
 class hole(OpenSCADObject):
     def __init__(self):
         OpenSCADObject.__init__(self, 'hole', {})
         self.set_hole(True)
 
+
 class part(OpenSCADObject):
     def __init__(self):
         OpenSCADObject.__init__(self, 'part', {})
         self.set_part_root(True)
+
 
 class translate(OpenSCADObject):
     '''
@@ -262,8 +285,10 @@ class translate(OpenSCADObject):
     :param v: X, Y and Z translation
     :type v: 3 value sequence
     '''
-    def __init__(self, v:P3=None):
+
+    def __init__(self, v: P3 = None):
         OpenSCADObject.__init__(self, 'translate', {'v': v})
+
 
 class scale(OpenSCADObject):
     '''
@@ -272,8 +297,10 @@ class scale(OpenSCADObject):
     :param v: X, Y and Z scale factor
     :type v: 3 value sequence
     '''
-    def __init__(self, v:P3=None):
+
+    def __init__(self, v: P3 = None):
         OpenSCADObject.__init__(self, 'scale', {'v': v})
+
 
 class rotate(OpenSCADObject):
     '''
@@ -286,8 +313,10 @@ class rotate(OpenSCADObject):
     :param v: sequence specifying 0 or 1 to indicate which axis to rotate by 'a' degrees. Ignored if 'a' is a sequence.
     :type v: 3 value sequence
     '''
-    def __init__(self, a:Union[float, Vec3]=None, v:Vec3=None):
+
+    def __init__(self, a: Union[float, Vec3] = None, v: Vec3 = None):
         OpenSCADObject.__init__(self, 'rotate', {'a': a, 'v': v})
+
 
 class mirror(OpenSCADObject):
     '''
@@ -297,8 +326,10 @@ class mirror(OpenSCADObject):
     :type v: 3 number sequence
 
     '''
-    def __init__(self, v:Vec3):
+
+    def __init__(self, v: Vec3):
         OpenSCADObject.__init__(self, 'mirror', {'v': v})
+
 
 class resize(OpenSCADObject):
     '''
@@ -310,8 +341,10 @@ class resize(OpenSCADObject):
     :param auto: 3-tuple of booleans to specify which axes should be scaled
     :type auto: 3 boolean sequence
     '''
-    def __init__(self, newsize:Vec3, auto:Tuple[bool,bool,bool]=None):
+
+    def __init__(self, newsize: Vec3, auto: Tuple[bool, bool, bool] = None):
         OpenSCADObject.__init__(self, 'resize', {'newsize': newsize, 'auto': auto})
+
 
 class multmatrix(OpenSCADObject):
     '''
@@ -321,8 +354,10 @@ class multmatrix(OpenSCADObject):
     :param m: transformation matrix
     :type m: sequence of 4 sequences, each containing 4 numbers.
     '''
-    def __init__(self, m:Tuple[Vec4, Vec4, Vec4, Vec4]):
+
+    def __init__(self, m: Tuple[Vec4, Vec4, Vec4, Vec4]):
         OpenSCADObject.__init__(self, 'multmatrix', {'m': m})
+
 
 class color(OpenSCADObject):
     '''
@@ -334,8 +369,10 @@ class color(OpenSCADObject):
     :param c: RGB color + alpha value.
     :type c: sequence of 3 or 4 numbers between 0 and 1
     '''
-    def __init__(self, c:Vec34):
+
+    def __init__(self, c: Vec34):
         OpenSCADObject.__init__(self, 'color', {'c': c})
+
 
 class minkowski(OpenSCADObject):
     '''
@@ -343,6 +380,7 @@ class minkowski(OpenSCADObject):
     sum <http://www.cgal.org/Manual/latest/doc_html/cgal_manual/Minkowski_sum_3/Chapter_main.html>`__
     of child nodes.
     '''
+
     def __init__(self):
         OpenSCADObject.__init__(self, 'minkowski', {})
 
@@ -365,11 +403,12 @@ class offset(OpenSCADObject):
         their intersection).
     :type chamfer: bool
     '''
-    def __init__(self, r:float = None, delta:float=None, chamfer:bool=False):
+
+    def __init__(self, r: float = None, delta: float = None, chamfer: bool = False):
         if r:
-            kwargs = {'r':r}
+            kwargs = {'r': r}
         elif delta:
-            kwargs = {'delta':delta, 'chamfer':chamfer}
+            kwargs = {'delta': delta, 'chamfer': chamfer}
         else:
             raise ValueError("offset(): Must supply r or delta")
         OpenSCADObject.__init__(self, 'offset', kwargs)
@@ -381,8 +420,10 @@ class hull(OpenSCADObject):
     hull <http://www.cgal.org/Manual/latest/doc_html/cgal_manual/Convex_hull_2/Chapter_main.html>`__
     of child nodes.
     '''
+
     def __init__(self):
         OpenSCADObject.__init__(self, 'hull', {})
+
 
 class render(OpenSCADObject):
     '''
@@ -392,8 +433,10 @@ class render(OpenSCADObject):
     :param convexity: The convexity parameter specifies the maximum number of front sides (back sides) a ray intersecting the object might penetrate. This parameter is only needed for correctly displaying the object in OpenCSG preview mode and has no effect on the polyhedron rendering.
     :type convexity: int
     '''
-    def __init__(self, convexity:int=None):
+
+    def __init__(self, convexity: int = None):
         OpenSCADObject.__init__(self, 'render', {'convexity': convexity})
+
 
 class linear_extrude(OpenSCADObject):
     '''
@@ -425,12 +468,14 @@ class linear_extrude(OpenSCADObject):
     :type scale: number
 
     '''
-    def __init__(self, height:float = None, center:bool = None, convexity:int = None, 
-                 twist:float = None, slices:int=None, scale:float = None):
+
+    def __init__(self, height: float = None, center: bool = None, convexity: int = None,
+                 twist: float = None, slices: int = None, scale: float = None):
         OpenSCADObject.__init__(self, 'linear_extrude',
                                 {'height': height, 'center': center,
                                  'convexity': convexity, 'twist': twist,
-                                 'slices': slices, 'scale':scale})
+                                 'slices': slices, 'scale': scale})
+
 
 class rotate_extrude(OpenSCADObject):
     '''
@@ -461,20 +506,23 @@ class rotate_extrude(OpenSCADObject):
     :type convexity: int
 
     '''
-    def __init__(self, angle:float=360, convexity:int=None, segments:int=None):
+
+    def __init__(self, angle: float = 360, convexity: int = None, segments: int = None):
         OpenSCADObject.__init__(self, 'rotate_extrude',
-                                {'angle': angle, 'segments': segments, 
+                                {'angle': angle, 'segments': segments,
                                  'convexity': convexity})
 
+
 class dxf_linear_extrude(OpenSCADObject):
-    def __init__(self, file:str, layer:float = None, height:float=None, 
-                 center:bool = None, convexity:int=None, twist:float=None, 
-                 slices:int=None):
+    def __init__(self, file: str, layer: float = None, height: float = None,
+                 center: bool = None, convexity: int = None, twist: float = None,
+                 slices: int = None):
         OpenSCADObject.__init__(self, 'dxf_linear_extrude',
                                 {'file': file, 'layer': layer,
                                  'height': height, 'center': center,
                                  'convexity': convexity, 'twist': twist,
                                  'slices': slices})
+
 
 class projection(OpenSCADObject):
     '''
@@ -486,8 +534,10 @@ class projection(OpenSCADObject):
     considered as well (creating a proper projection).
     :type cut: boolean
     '''
-    def __init__(self, cut:bool=None):
+
+    def __init__(self, cut: bool = None):
         OpenSCADObject.__init__(self, 'projection', {'cut': cut})
+
 
 class surface(OpenSCADObject):
     '''
@@ -512,10 +562,12 @@ class surface(OpenSCADObject):
     preview mode and has no effect on the polyhedron rendering.
     :type convexity: int
     '''
-    def __init__(self, file, center:bool = None, convexity:int = None, invert=None):
+
+    def __init__(self, file, center: bool = None, convexity: int = None, invert=None):
         OpenSCADObject.__init__(self, 'surface',
                                 {'file': file, 'center': center,
                                  'convexity': convexity, 'invert': invert})
+
 
 class text(OpenSCADObject):
     '''
@@ -565,9 +617,10 @@ class text(OpenSCADObject):
     freetype
     :type segments: int
     '''
-    def __init__(self, text:str, size:float = None, font:str=None, halign:str=None, 
-                 valign:str=None, spacing:float=None, direction:str=None, 
-                 language:str=None, script:str=None, segments:int=None):
+
+    def __init__(self, text: str, size: float = None, font: str = None, halign: str = None,
+                 valign: str = None, spacing: float = None, direction: str = None,
+                 language: str = None, script: str = None, segments: int = None):
         OpenSCADObject.__init__(self, 'text',
                                 {'text': text, 'size': size, 'font': font,
                                  'halign': halign, 'valign': valign,
@@ -575,11 +628,13 @@ class text(OpenSCADObject):
                                  'language': language, 'script': script,
                                  'segments': segments})
 
+
 class child(OpenSCADObject):
-    def __init__(self, index:int=None, vector:Sequence[int] = None, range=None):
+    def __init__(self, index: int = None, vector: Sequence[int] = None, range=None):
         OpenSCADObject.__init__(self, 'child',
                                 {'index': index, 'vector': vector,
                                  'range': range})
+
 
 class children(OpenSCADObject):
     '''
@@ -597,22 +652,26 @@ class children(OpenSCADObject):
 
     :param range: [:] or [::]. select children between to , incremented by (default 1).
     '''
-    def __init__(self, index:int=None, vector:float = None, range:P23=None):
+
+    def __init__(self, index: int = None, vector: float = None, range: P23 = None):
         OpenSCADObject.__init__(self, 'children',
                                 {'index': index, 'vector': vector,
                                  'range': range})
 
+
 class import_stl(OpenSCADObject):
-    def __init__(self, file:str, origin:P2=(0, 0), convexity:int=None,layer:int = None):
+    def __init__(self, file: str, origin: P2 = (0, 0), convexity: int = None, layer: int = None):
         OpenSCADObject.__init__(self, 'import',
-                                {'file': file, 'origin': origin, 
-                                'convexity': convexity, 'layer': layer})
+                                {'file': file, 'origin': origin,
+                                 'convexity': convexity, 'layer': layer})
+
 
 class import_dxf(OpenSCADObject):
-    def __init__(self, file, origin=(0, 0), convexity:int = None,layer:int = None):
+    def __init__(self, file, origin=(0, 0), convexity: int = None, layer: int = None):
         OpenSCADObject.__init__(self, 'import',
-                                {'file': file, 'origin': origin, 
-                                'convexity': convexity, 'layer': layer})
+                                {'file': file, 'origin': origin,
+                                 'convexity': convexity, 'layer': layer})
+
 
 class import_(OpenSCADObject):
     '''
@@ -628,46 +687,55 @@ class import_(OpenSCADObject):
     preview mode and has no effect on the polyhedron rendering.
     :type convexity: int
     '''
-    def __init__(self, file:str, origin:P2=(0, 0), convexity:int = None, layer:int = None):
+
+    def __init__(self, file: str, origin: P2 = (0, 0), convexity: int = None, layer: int = None):
         OpenSCADObject.__init__(self, 'import',
-                                {'file': file, 'origin': origin, 
-                                'convexity': convexity, 'layer': layer})
+                                {'file': file, 'origin': origin,
+                                 'convexity': convexity, 'layer': layer})
+
 
 class intersection_for(OpenSCADObject):
     '''
     Iterate over the values in a vector or range and take an
     intersection of the contents.
     '''
-    def __init__(self, n:int):
+
+    def __init__(self, n: int):
         OpenSCADObject.__init__(self, 'intersection_for', {'n': n})
+
 
 class assign(OpenSCADObject):
     def __init__(self):
         OpenSCADObject.__init__(self, 'assign', {})
 
+
 # ================================
 # = Modifier Convenience Methods =
 # ================================
-def debug(openscad_obj:OpenSCADObject) -> OpenSCADObject:
+def debug(openscad_obj: OpenSCADObject) -> OpenSCADObject:
     openscad_obj.set_modifier("#")
     return openscad_obj
 
-def background(openscad_obj:OpenSCADObject) -> OpenSCADObject:
+
+def background(openscad_obj: OpenSCADObject) -> OpenSCADObject:
     openscad_obj.set_modifier("%")
     return openscad_obj
 
-def root(openscad_obj:OpenSCADObject) -> OpenSCADObject:
+
+def root(openscad_obj: OpenSCADObject) -> OpenSCADObject:
     openscad_obj.set_modifier("!")
     return openscad_obj
 
-def disable(openscad_obj:OpenSCADObject) -> OpenSCADObject:
+
+def disable(openscad_obj: OpenSCADObject) -> OpenSCADObject:
     openscad_obj.set_modifier("*")
     return openscad_obj
+
 
 # ===========================
 # = IMPORTING OPENSCAD CODE =
 # ===========================
-def import_scad(scad_filepath:PathStr) -> Optional[SimpleNamespace]:
+def import_scad(scad_filepath: PathStr) -> Optional[SimpleNamespace]:
     '''
     import_scad() is the namespaced, more Pythonic way to import OpenSCAD code.
     Return a python namespace containing all imported SCAD modules
@@ -686,9 +754,9 @@ def import_scad(scad_filepath:PathStr) -> Optional[SimpleNamespace]:
     '''
     scad = Path(scad_filepath)
 
-    namespace:Optional[SimpleNamespace] = SimpleNamespace()
+    namespace: Optional[SimpleNamespace] = SimpleNamespace()
     scad_found = False
-    
+
     if scad.is_file():
         scad_found = True
         use(scad.absolute().as_posix(), dest_namespace_dict=namespace.__dict__)
@@ -697,7 +765,7 @@ def import_scad(scad_filepath:PathStr) -> Optional[SimpleNamespace]:
             subspace = import_scad(f.absolute().as_posix())
             setattr(namespace, f.stem, subspace)
             scad_found = True
-        
+
         # recurse through subdirectories, adding namespaces only if they have
         # valid scad code under them.
         subdirs = list([d for d in scad.iterdir() if d.is_dir()])
@@ -710,13 +778,14 @@ def import_scad(scad_filepath:PathStr) -> Optional[SimpleNamespace]:
     namespace = namespace if scad_found else None
     return namespace
 
+
 # use() & include() mimic OpenSCAD's use/include mechanics.
 # -- use() makes methods in scad_file_path.scad available to
 #   be called.
 # --include() makes those methods available AND executes all code in
 #   scad_file_path.scad, which may have side effects.
 #   Unless you have a specific need, call use().
-def use(scad_file_path:PathStr, use_not_include:bool=True, dest_namespace_dict:Dict=None):
+def use(scad_file_path: PathStr, use_not_include: bool = True, dest_namespace_dict: Dict = None):
     '''
     Opens scad_file_path, parses it for all usable calls,
     and adds them to caller's namespace.
@@ -725,11 +794,11 @@ def use(scad_file_path:PathStr, use_not_include:bool=True, dest_namespace_dict:D
     # the global namespace with them
     from pathlib import Path
     from .solidpython import parse_scad_callables
-    from .solidpython import new_openscad_class_str 
+    from .solidpython import new_openscad_class_str
     from .solidpython import calling_module
 
     scad_file_path = Path(scad_file_path)
-    
+
     contents = None
     try:
         contents = scad_file_path.read_text()
@@ -743,8 +812,8 @@ def use(scad_file_path:PathStr, use_not_include:bool=True, dest_namespace_dict:D
     symbols_dicts = parse_scad_callables(contents)
 
     for sd in symbols_dicts:
-        class_str = new_openscad_class_str(sd['name'], sd['args'], sd['kwargs'], 
-                                            scad_file_path.as_posix(), use_not_include)
+        class_str = new_openscad_class_str(sd['name'], sd['args'], sd['kwargs'],
+                                           scad_file_path.as_posix(), use_not_include)
         # If this is called from 'include', we have to look deeper in the stack
         # to find the right module to add the new class to.
         if dest_namespace_dict is None:
@@ -756,8 +825,9 @@ def use(scad_file_path:PathStr, use_not_include:bool=True, dest_namespace_dict:D
             classname = sd['name']
             msg = f"Unable to import SCAD module: `{classname}` from `{scad_file_path.name}`, with error: {e}"
             print(msg)
-        
+
     return True
 
-def include(scad_file_path:str) -> bool:
+
+def include(scad_file_path: str) -> bool:
     return use(scad_file_path, use_not_include=False)

--- a/solid/objects.py
+++ b/solid/objects.py
@@ -38,7 +38,7 @@ class polygon(OpenSCADObject):
     references to the elements of the *points* vector.)
     """
 
-    def __init__(self, points: Points, paths: Indexes = None):
+    def __init__(self, points: Points, paths: Indexes = None) -> None:
         if not paths:
             paths = [list(range(len(points)))]
         super().__init__('polygon',
@@ -60,7 +60,7 @@ class circle(OpenSCADObject):
     :type segments: int
     """
 
-    def __init__(self, r: float = None, d: float = None, segments: int = None):
+    def __init__(self, r: float = None, d: float = None, segments: int = None) -> None:
         super().__init__('circle',
                          {'r': r, 'd': d, 'segments': segments})
 
@@ -83,7 +83,7 @@ class square(OpenSCADObject):
     :type center: boolean
     """
 
-    def __init__(self, size: ScadSize = None, center: bool = None):
+    def __init__(self, size: ScadSize = None, center: bool = None) -> None:
         super().__init__('square',
                          {'size': size, 'center': center})
 
@@ -103,7 +103,7 @@ class sphere(OpenSCADObject):
     :type segments: int
     """
 
-    def __init__(self, r: float = None, d: float = None, segments: int = None):
+    def __init__(self, r: float = None, d: float = None, segments: int = None) -> None:
         super().__init__('sphere',
                          {'r': r, 'd': d, 'segments': segments})
 
@@ -126,7 +126,7 @@ class cube(OpenSCADObject):
     :type center: boolean
     """
 
-    def __init__(self, size: ScadSize = None, center: bool = None):
+    def __init__(self, size: ScadSize = None, center: bool = None) -> None:
         super().__init__('cube',
                          {'size': size, 'center': center})
 
@@ -171,7 +171,7 @@ class cylinder(OpenSCADObject):
 
     def __init__(self, r: float = None, h: float = None, r1: float = None, r2: float = None,
                  d: float = None, d1: float = None, d2: float = None, center: bool = None,
-                 segments: int = None):
+                 segments: int = None) -> None:
         super().__init__('cylinder',
                          {'r': r, 'h': h, 'r1': r1, 'r2': r2, 'd': d,
                           'd1': d1, 'd2': d2, 'center': center,
@@ -206,7 +206,7 @@ class polyhedron(OpenSCADObject):
     :type convexity: int
     """
 
-    def __init__(self, points: P3s, faces: Indexes, convexity: int = None, triangles: Indexes = None):
+    def __init__(self, points: P3s, faces: Indexes, convexity: int = None, triangles: Indexes = None) -> None:
         super().__init__('polyhedron',
                          {'points': points, 'faces': faces,
                           'convexity': convexity,
@@ -219,7 +219,7 @@ class union(OpenSCADObject):
     children.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__('union', {})
 
     def __add__(self, x: OpenSCADObjectPlus) -> OpenSCADObject:
@@ -237,7 +237,7 @@ class intersection(OpenSCADObject):
     **overlapping** portion
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__('intersection', {})
 
     def __mul__(self, x: OpenSCADObjectPlus) -> OpenSCADObject:
@@ -254,7 +254,7 @@ class difference(OpenSCADObject):
     Subtracts the 2nd (and all further) child nodes from the first one.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__('difference', {})
 
     def __sub__(self, x: OpenSCADObjectPlus) -> OpenSCADObject:
@@ -267,13 +267,13 @@ class difference(OpenSCADObject):
 
 
 class hole(OpenSCADObject):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__('hole', {})
         self.set_hole(True)
 
 
 class part(OpenSCADObject):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__('part', {})
         self.set_part_root(True)
 
@@ -286,7 +286,7 @@ class translate(OpenSCADObject):
     :type v: 3 value sequence
     """
 
-    def __init__(self, v: P3 = None):
+    def __init__(self, v: P3 = None) -> None:
         super().__init__('translate', {'v': v})
 
 
@@ -298,7 +298,7 @@ class scale(OpenSCADObject):
     :type v: 3 value sequence
     """
 
-    def __init__(self, v: P3 = None):
+    def __init__(self, v: P3 = None) -> None:
         super().__init__('scale', {'v': v})
 
 
@@ -314,7 +314,7 @@ class rotate(OpenSCADObject):
     :type v: 3 value sequence
     """
 
-    def __init__(self, a: Union[float, Vec3] = None, v: Vec3 = None):
+    def __init__(self, a: Union[float, Vec3] = None, v: Vec3 = None) -> None:
         super().__init__('rotate', {'a': a, 'v': v})
 
 
@@ -327,7 +327,7 @@ class mirror(OpenSCADObject):
 
     """
 
-    def __init__(self, v: Vec3):
+    def __init__(self, v: Vec3) -> None:
         super().__init__('mirror', {'v': v})
 
 
@@ -342,7 +342,7 @@ class resize(OpenSCADObject):
     :type auto: 3 boolean sequence
     """
 
-    def __init__(self, newsize: Vec3, auto: Tuple[bool, bool, bool] = None):
+    def __init__(self, newsize: Vec3, auto: Tuple[bool, bool, bool] = None) -> None:
         super().__init__('resize', {'newsize': newsize, 'auto': auto})
 
 
@@ -355,7 +355,7 @@ class multmatrix(OpenSCADObject):
     :type m: sequence of 4 sequences, each containing 4 numbers.
     """
 
-    def __init__(self, m: Tuple[Vec4, Vec4, Vec4, Vec4]):
+    def __init__(self, m: Tuple[Vec4, Vec4, Vec4, Vec4]) -> None:
         super().__init__('multmatrix', {'m': m})
 
 
@@ -370,7 +370,7 @@ class color(OpenSCADObject):
     :type c: sequence of 3 or 4 numbers between 0 and 1
     """
 
-    def __init__(self, c: Vec34):
+    def __init__(self, c: Vec34) -> None:
         super().__init__('color', {'c': c})
 
 
@@ -381,7 +381,7 @@ class minkowski(OpenSCADObject):
     of child nodes.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__('minkowski', {})
 
 
@@ -404,7 +404,7 @@ class offset(OpenSCADObject):
     :type chamfer: bool
     """
 
-    def __init__(self, r: float = None, delta: float = None, chamfer: bool = False):
+    def __init__(self, r: float = None, delta: float = None, chamfer: bool = False) -> None:
         if r:
             kwargs = {'r': r}
         elif delta:
@@ -421,7 +421,7 @@ class hull(OpenSCADObject):
     of child nodes.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__('hull', {})
 
 
@@ -434,7 +434,7 @@ class render(OpenSCADObject):
     :type convexity: int
     """
 
-    def __init__(self, convexity: int = None):
+    def __init__(self, convexity: int = None) -> None:
         super().__init__('render', {'convexity': convexity})
 
 
@@ -470,7 +470,7 @@ class linear_extrude(OpenSCADObject):
     """
 
     def __init__(self, height: float = None, center: bool = None, convexity: int = None,
-                 twist: float = None, slices: int = None, scale: float = None):
+                 twist: float = None, slices: int = None, scale: float = None) -> None:
         super().__init__('linear_extrude',
                          {'height': height, 'center': center,
                           'convexity': convexity, 'twist': twist,
@@ -507,7 +507,7 @@ class rotate_extrude(OpenSCADObject):
 
     """
 
-    def __init__(self, angle: float = 360, convexity: int = None, segments: int = None):
+    def __init__(self, angle: float = 360, convexity: int = None, segments: int = None) -> None:
         super().__init__('rotate_extrude',
                          {'angle': angle, 'segments': segments,
                           'convexity': convexity})
@@ -516,7 +516,7 @@ class rotate_extrude(OpenSCADObject):
 class dxf_linear_extrude(OpenSCADObject):
     def __init__(self, file: str, layer: float = None, height: float = None,
                  center: bool = None, convexity: int = None, twist: float = None,
-                 slices: int = None):
+                 slices: int = None) -> None:
         super().__init__('dxf_linear_extrude',
                          {'file': file, 'layer': layer,
                           'height': height, 'center': center,
@@ -535,7 +535,7 @@ class projection(OpenSCADObject):
     :type cut: boolean
     """
 
-    def __init__(self, cut: bool = None):
+    def __init__(self, cut: bool = None) -> None:
         super().__init__('projection', {'cut': cut})
 
 
@@ -563,7 +563,7 @@ class surface(OpenSCADObject):
     :type convexity: int
     """
 
-    def __init__(self, file, center: bool = None, convexity: int = None, invert=None):
+    def __init__(self, file, center: bool = None, convexity: int = None, invert=None) -> None:
         super().__init__('surface',
                          {'file': file, 'center': center,
                           'convexity': convexity, 'invert': invert})
@@ -620,7 +620,7 @@ class text(OpenSCADObject):
 
     def __init__(self, text: str, size: float = None, font: str = None, halign: str = None,
                  valign: str = None, spacing: float = None, direction: str = None,
-                 language: str = None, script: str = None, segments: int = None):
+                 language: str = None, script: str = None, segments: int = None) -> None:
         super().__init__('text',
                          {'text': text, 'size': size, 'font': font,
                           'halign': halign, 'valign': valign,
@@ -630,7 +630,7 @@ class text(OpenSCADObject):
 
 
 class child(OpenSCADObject):
-    def __init__(self, index: int = None, vector: Sequence[int] = None, range=None):
+    def __init__(self, index: int = None, vector: Sequence[int] = None, range=None) -> None:
         super().__init__('child',
                          {'index': index, 'vector': vector,
                           'range': range})
@@ -653,21 +653,21 @@ class children(OpenSCADObject):
     :param range: [:] or [::]. select children between to , incremented by (default 1).
     """
 
-    def __init__(self, index: int = None, vector: float = None, range: P23 = None):
+    def __init__(self, index: int = None, vector: float = None, range: P23 = None) -> None:
         super().__init__('children',
                          {'index': index, 'vector': vector,
                           'range': range})
 
 
 class import_stl(OpenSCADObject):
-    def __init__(self, file: str, origin: P2 = (0, 0), convexity: int = None, layer: int = None):
+    def __init__(self, file: str, origin: P2 = (0, 0), convexity: int = None, layer: int = None) -> None:
         super().__init__('import',
                          {'file': file, 'origin': origin,
                           'convexity': convexity, 'layer': layer})
 
 
 class import_dxf(OpenSCADObject):
-    def __init__(self, file, origin=(0, 0), convexity: int = None, layer: int = None):
+    def __init__(self, file, origin=(0, 0), convexity: int = None, layer: int = None) -> None:
         super().__init__('import',
                          {'file': file, 'origin': origin,
                           'convexity': convexity, 'layer': layer})
@@ -688,7 +688,7 @@ class import_(OpenSCADObject):
     :type convexity: int
     """
 
-    def __init__(self, file: str, origin: P2 = (0, 0), convexity: int = None, layer: int = None):
+    def __init__(self, file: str, origin: P2 = (0, 0), convexity: int = None, layer: int = None) -> None:
         super().__init__('import',
                          {'file': file, 'origin': origin,
                           'convexity': convexity, 'layer': layer})
@@ -700,12 +700,12 @@ class intersection_for(OpenSCADObject):
     intersection of the contents.
     """
 
-    def __init__(self, n: int):
+    def __init__(self, n: int) -> None:
         super().__init__('intersection_for', {'n': n})
 
 
 class assign(OpenSCADObject):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__('assign', {})
 
 

--- a/solid/objects.py
+++ b/solid/objects.py
@@ -1,12 +1,11 @@
 """
 Classes for OpenSCAD builtins
 """
-from .solidpython import OpenSCADObject
-from .solidpython import IncludedOpenSCADObject
 from pathlib import Path
-
-from typing import Sequence, Tuple, Union, Optional, Dict
 from types import SimpleNamespace
+from typing import Dict, Optional, Sequence, Tuple, Union
+
+from .solidpython import OpenSCADObject
 
 PathStr = Union[Path, str]
 

--- a/solid/objects.py
+++ b/solid/objects.py
@@ -24,7 +24,7 @@ OpenSCADObjectPlus = Union[OpenSCADObject, Sequence[OpenSCADObject]]
 
 
 class polygon(OpenSCADObject):
-    '''
+    """
     Create a polygon with the specified points and paths.
 
     :param points: the list of points of the polygon
@@ -36,7 +36,7 @@ class polygon(OpenSCADObject):
     polygon has holes. The parameter is optional and if omitted the points are 
     assumed in order. (The 'pN' components of the *paths* vector are 0-indexed 
     references to the elements of the *points* vector.)
-    '''
+    """
 
     def __init__(self, points: Points, paths: Indexes = None):
         if not paths:
@@ -46,7 +46,7 @@ class polygon(OpenSCADObject):
 
 
 class circle(OpenSCADObject):
-    '''
+    """
     Creates a circle at the origin of the coordinate system. The argument
     name is optional.
 
@@ -58,7 +58,7 @@ class circle(OpenSCADObject):
 
     :param segments: Number of fragments in 360 degrees.
     :type segments: int
-    '''
+    """
 
     def __init__(self, r: float = None, d: float = None, segments: int = None):
         OpenSCADObject.__init__(self, 'circle',
@@ -66,7 +66,7 @@ class circle(OpenSCADObject):
 
 
 class square(OpenSCADObject):
-    '''
+    """
     Creates a square at the origin of the coordinate system. When center is
     True the square will be centered on the origin, otherwise it is created
     in the first quadrant. The argument names are optional if the arguments
@@ -81,7 +81,7 @@ class square(OpenSCADObject):
     object is centered at (0,0). Otherwise, the square is placed in the positive 
     quadrant with one corner at (0,0). Defaults to False.
     :type center: boolean
-    '''
+    """
 
     def __init__(self, size: ScadSize = None, center: bool = None):
         OpenSCADObject.__init__(self, 'square',
@@ -89,7 +89,7 @@ class square(OpenSCADObject):
 
 
 class sphere(OpenSCADObject):
-    '''
+    """
     Creates a sphere at the origin of the coordinate system. The argument
     name is optional.
 
@@ -101,7 +101,7 @@ class sphere(OpenSCADObject):
 
     :param segments: Resolution of the sphere
     :type segments: int
-    '''
+    """
 
     def __init__(self, r: float = None, d: float = None, segments: int = None):
         OpenSCADObject.__init__(self, 'sphere',
@@ -109,7 +109,7 @@ class sphere(OpenSCADObject):
 
 
 class cube(OpenSCADObject):
-    '''
+    """
     Creates a cube at the origin of the coordinate system. When center is
     True the cube will be centered on the origin, otherwise it is created in
     the first octant. The argument names are optional if the arguments are
@@ -124,7 +124,7 @@ class cube(OpenSCADObject):
     object is centered at (0,0,0). Otherwise, the cube is placed in the positive 
     quadrant with one corner at (0,0,0). Defaults to False
     :type center: boolean
-    '''
+    """
 
     def __init__(self, size: ScadSize = None, center: bool = None):
         OpenSCADObject.__init__(self, 'cube',
@@ -132,7 +132,7 @@ class cube(OpenSCADObject):
 
 
 class cylinder(OpenSCADObject):
-    '''
+    """
     Creates a cylinder or cone at the origin of the coordinate system. A
     single radius (r) makes a cylinder, two different radi (r1, r2) make a
     cone.
@@ -167,7 +167,7 @@ class cylinder(OpenSCADObject):
 
     :param segments: Number of fragments in 360 degrees.
     :type segments: int
-    '''
+    """
 
     def __init__(self, r: float = None, h: float = None, r1: float = None, r2: float = None,
                  d: float = None, d1: float = None, d2: float = None, center: bool = None,
@@ -179,7 +179,7 @@ class cylinder(OpenSCADObject):
 
 
 class polyhedron(OpenSCADObject):
-    '''
+    """
     Create a polyhedron with a list of points and a list of faces. The point
     list is all the vertices of the shape, the faces list is how the points
     relate to the surfaces of the polyhedron.
@@ -204,7 +204,7 @@ class polyhedron(OpenSCADObject):
     parameter is only needed for correctly displaying the object in OpenCSG 
     preview mode and has no effect on the polyhedron rendering.
     :type convexity: int
-    '''
+    """
 
     def __init__(self, points: P3s, faces: Indexes, convexity: int = None, triangles: Indexes = None):
         OpenSCADObject.__init__(self, 'polyhedron',
@@ -214,10 +214,10 @@ class polyhedron(OpenSCADObject):
 
 
 class union(OpenSCADObject):
-    '''
+    """
     Creates a union of all its child nodes. This is the **sum** of all
     children.
-    '''
+    """
 
     def __init__(self):
         OpenSCADObject.__init__(self, 'union', {})
@@ -232,10 +232,10 @@ class union(OpenSCADObject):
 
 
 class intersection(OpenSCADObject):
-    '''
+    """
     Creates the intersection of all child nodes. This keeps the
     **overlapping** portion
-    '''
+    """
 
     def __init__(self):
         OpenSCADObject.__init__(self, 'intersection', {})
@@ -250,9 +250,9 @@ class intersection(OpenSCADObject):
 
 
 class difference(OpenSCADObject):
-    '''
+    """
     Subtracts the 2nd (and all further) child nodes from the first one.
-    '''
+    """
 
     def __init__(self):
         OpenSCADObject.__init__(self, 'difference', {})
@@ -279,31 +279,31 @@ class part(OpenSCADObject):
 
 
 class translate(OpenSCADObject):
-    '''
+    """
     Translates (moves) its child elements along the specified vector.
 
     :param v: X, Y and Z translation
     :type v: 3 value sequence
-    '''
+    """
 
     def __init__(self, v: P3 = None):
         OpenSCADObject.__init__(self, 'translate', {'v': v})
 
 
 class scale(OpenSCADObject):
-    '''
+    """
     Scales its child elements using the specified vector.
 
     :param v: X, Y and Z scale factor
     :type v: 3 value sequence
-    '''
+    """
 
     def __init__(self, v: P3 = None):
         OpenSCADObject.__init__(self, 'scale', {'v': v})
 
 
 class rotate(OpenSCADObject):
-    '''
+    """
     Rotates its child 'a' degrees about the origin of the coordinate system
     or around an arbitrary axis.
 
@@ -312,27 +312,27 @@ class rotate(OpenSCADObject):
 
     :param v: sequence specifying 0 or 1 to indicate which axis to rotate by 'a' degrees. Ignored if 'a' is a sequence.
     :type v: 3 value sequence
-    '''
+    """
 
     def __init__(self, a: Union[float, Vec3] = None, v: Vec3 = None):
         OpenSCADObject.__init__(self, 'rotate', {'a': a, 'v': v})
 
 
 class mirror(OpenSCADObject):
-    '''
+    """
     Mirrors the child element on a plane through the origin.
 
     :param v: the normal vector of a plane intersecting the origin through which to mirror the object.
     :type v: 3 number sequence
 
-    '''
+    """
 
     def __init__(self, v: Vec3):
         OpenSCADObject.__init__(self, 'mirror', {'v': v})
 
 
 class resize(OpenSCADObject):
-    '''
+    """
     Modify the size of the child object to match the given new size.
 
     :param newsize: X, Y and Z values
@@ -340,27 +340,27 @@ class resize(OpenSCADObject):
     
     :param auto: 3-tuple of booleans to specify which axes should be scaled
     :type auto: 3 boolean sequence
-    '''
+    """
 
     def __init__(self, newsize: Vec3, auto: Tuple[bool, bool, bool] = None):
         OpenSCADObject.__init__(self, 'resize', {'newsize': newsize, 'auto': auto})
 
 
 class multmatrix(OpenSCADObject):
-    '''
+    """
     Multiplies the geometry of all child elements with the given 4x4
     transformation matrix.
 
     :param m: transformation matrix
     :type m: sequence of 4 sequences, each containing 4 numbers.
-    '''
+    """
 
     def __init__(self, m: Tuple[Vec4, Vec4, Vec4, Vec4]):
         OpenSCADObject.__init__(self, 'multmatrix', {'m': m})
 
 
 class color(OpenSCADObject):
-    '''
+    """
     Displays the child elements using the specified RGB color + alpha value.
     This is only used for the F5 preview as CGAL and STL (F6) do not
     currently support color. The alpha value will default to 1.0 (opaque) if
@@ -368,25 +368,25 @@ class color(OpenSCADObject):
 
     :param c: RGB color + alpha value.
     :type c: sequence of 3 or 4 numbers between 0 and 1
-    '''
+    """
 
     def __init__(self, c: Vec34):
         OpenSCADObject.__init__(self, 'color', {'c': c})
 
 
 class minkowski(OpenSCADObject):
-    '''
+    """
     Renders the `minkowski
     sum <http://www.cgal.org/Manual/latest/doc_html/cgal_manual/Minkowski_sum_3/Chapter_main.html>`__
     of child nodes.
-    '''
+    """
 
     def __init__(self):
         OpenSCADObject.__init__(self, 'minkowski', {})
 
 
 class offset(OpenSCADObject):
-    '''
+    """
     
     :param r: Amount to offset the polygon (rounded corners). When negative, 
         the polygon is offset inwards. The parameter r specifies the radius 
@@ -402,7 +402,7 @@ class offset(OpenSCADObject):
         should be chamfered (cut off with a straight line) or not (extended to 
         their intersection).
     :type chamfer: bool
-    '''
+    """
 
     def __init__(self, r: float = None, delta: float = None, chamfer: bool = False):
         if r:
@@ -415,31 +415,31 @@ class offset(OpenSCADObject):
 
 
 class hull(OpenSCADObject):
-    '''
+    """
     Renders the `convex
     hull <http://www.cgal.org/Manual/latest/doc_html/cgal_manual/Convex_hull_2/Chapter_main.html>`__
     of child nodes.
-    '''
+    """
 
     def __init__(self):
         OpenSCADObject.__init__(self, 'hull', {})
 
 
 class render(OpenSCADObject):
-    '''
+    """
     Always calculate the CSG model for this tree (even in OpenCSG preview
     mode).
 
     :param convexity: The convexity parameter specifies the maximum number of front sides (back sides) a ray intersecting the object might penetrate. This parameter is only needed for correctly displaying the object in OpenCSG preview mode and has no effect on the polyhedron rendering.
     :type convexity: int
-    '''
+    """
 
     def __init__(self, convexity: int = None):
         OpenSCADObject.__init__(self, 'render', {'convexity': convexity})
 
 
 class linear_extrude(OpenSCADObject):
-    '''
+    """
     Linear Extrusion is a modeling operation that takes a 2D polygon as
     input and extends it in the third dimension. This way a 3D shape is
     created.
@@ -467,7 +467,7 @@ class linear_extrude(OpenSCADObject):
     :param scale: relative size of the top of the extrusion compared to the start
     :type scale: number
 
-    '''
+    """
 
     def __init__(self, height: float = None, center: bool = None, convexity: int = None,
                  twist: float = None, slices: int = None, scale: float = None):
@@ -478,7 +478,7 @@ class linear_extrude(OpenSCADObject):
 
 
 class rotate_extrude(OpenSCADObject):
-    '''
+    """
     A rotational extrusion is a Linear Extrusion with a twist, literally.
     Unfortunately, it can not be used to produce a helix for screw threads
     as the 2D outline must be normal to the axis of rotation, ie they need
@@ -505,7 +505,7 @@ class rotate_extrude(OpenSCADObject):
     preview mode and has no effect on the polyhedron rendering.
     :type convexity: int
 
-    '''
+    """
 
     def __init__(self, angle: float = 360, convexity: int = None, segments: int = None):
         OpenSCADObject.__init__(self, 'rotate_extrude',
@@ -525,7 +525,7 @@ class dxf_linear_extrude(OpenSCADObject):
 
 
 class projection(OpenSCADObject):
-    '''
+    """
     Creates 2d shapes from 3d models, and export them to the dxf format.
     It works by projecting a 3D model to the (x,y) plane, with z at 0.
 
@@ -533,14 +533,14 @@ class projection(OpenSCADObject):
     cutting the object) When False points above and below the plane will be 
     considered as well (creating a proper projection).
     :type cut: boolean
-    '''
+    """
 
     def __init__(self, cut: bool = None):
         OpenSCADObject.__init__(self, 'projection', {'cut': cut})
 
 
 class surface(OpenSCADObject):
-    '''
+    """
     Surface reads information from text or image files.
 
     :param file: The path to the file containing the heightmap data.
@@ -561,7 +561,7 @@ class surface(OpenSCADObject):
     This parameter is only needed for correctly displaying the object in OpenCSG 
     preview mode and has no effect on the polyhedron rendering.
     :type convexity: int
-    '''
+    """
 
     def __init__(self, file, center: bool = None, convexity: int = None, invert=None):
         OpenSCADObject.__init__(self, 'surface',
@@ -570,7 +570,7 @@ class surface(OpenSCADObject):
 
 
 class text(OpenSCADObject):
-    '''
+    """
     Create text using fonts installed on the local system or provided as separate 
     font file.
 
@@ -616,7 +616,7 @@ class text(OpenSCADObject):
     :param segments: used for subdividing the curved path segments provided by 
     freetype
     :type segments: int
-    '''
+    """
 
     def __init__(self, text: str, size: float = None, font: str = None, halign: str = None,
                  valign: str = None, spacing: float = None, direction: str = None,
@@ -637,7 +637,7 @@ class child(OpenSCADObject):
 
 
 class children(OpenSCADObject):
-    '''
+    """
     The child nodes of the module instantiation can be accessed using the
     children() statement within the module. The number of module children
     can be accessed using the $children variable.
@@ -651,7 +651,7 @@ class children(OpenSCADObject):
     :type vector: sequence of int
 
     :param range: [:] or [::]. select children between to , incremented by (default 1).
-    '''
+    """
 
     def __init__(self, index: int = None, vector: float = None, range: P23 = None):
         OpenSCADObject.__init__(self, 'children',
@@ -674,7 +674,7 @@ class import_dxf(OpenSCADObject):
 
 
 class import_(OpenSCADObject):
-    '''
+    """
     Imports a file for use in the current OpenSCAD model. OpenSCAD currently
     supports import of DXF and STL (both ASCII and Binary) files.
 
@@ -686,7 +686,7 @@ class import_(OpenSCADObject):
     parameter is only needed for correctly displaying the object in OpenCSG 
     preview mode and has no effect on the polyhedron rendering.
     :type convexity: int
-    '''
+    """
 
     def __init__(self, file: str, origin: P2 = (0, 0), convexity: int = None, layer: int = None):
         OpenSCADObject.__init__(self, 'import',
@@ -695,10 +695,10 @@ class import_(OpenSCADObject):
 
 
 class intersection_for(OpenSCADObject):
-    '''
+    """
     Iterate over the values in a vector or range and take an
     intersection of the contents.
-    '''
+    """
 
     def __init__(self, n: int):
         OpenSCADObject.__init__(self, 'intersection_for', {'n': n})
@@ -736,7 +736,7 @@ def disable(openscad_obj: OpenSCADObject) -> OpenSCADObject:
 # = IMPORTING OPENSCAD CODE =
 # ===========================
 def import_scad(scad_filepath: PathStr) -> Optional[SimpleNamespace]:
-    '''
+    """
     import_scad() is the namespaced, more Pythonic way to import OpenSCAD code.
     Return a python namespace containing all imported SCAD modules
 
@@ -751,7 +751,7 @@ def import_scad(scad_filepath: PathStr) -> Optional[SimpleNamespace]:
         mcad = solid.import_scad('<PATH_TO/MCAD')
         dir(mcad) # => ['bearing', 'boxes', 'constants', 'curves',...]
         dir(mcad.bearing) # => ['bearing', 'bearingDimensions', ...]
-    '''
+    """
     scad = Path(scad_filepath)
 
     namespace: Optional[SimpleNamespace] = SimpleNamespace()
@@ -786,10 +786,10 @@ def import_scad(scad_filepath: PathStr) -> Optional[SimpleNamespace]:
 #   scad_file_path.scad, which may have side effects.
 #   Unless you have a specific need, call use().
 def use(scad_file_path: PathStr, use_not_include: bool = True, dest_namespace_dict: Dict = None):
-    '''
+    """
     Opens scad_file_path, parses it for all usable calls,
     and adds them to caller's namespace.
-    '''
+    """
     # These functions in solidpython are used here and only here; don't pollute
     # the global namespace with them
     from pathlib import Path

--- a/solid/objects.py
+++ b/solid/objects.py
@@ -134,7 +134,7 @@ class cube(OpenSCADObject):
 class cylinder(OpenSCADObject):
     """
     Creates a cylinder or cone at the origin of the coordinate system. A
-    single radius (r) makes a cylinder, two different radi (r1, r2) make a
+    single radius (r) makes a cylinder, two different radii (r1, r2) make a
     cone.
 
     :param h: This is the height of the cylinder. Default value is 1.
@@ -269,13 +269,13 @@ class difference(OpenSCADObject):
 class hole(OpenSCADObject):
     def __init__(self) -> None:
         super().__init__('hole', {})
-        self.set_hole(True)
+        self.set_hole(is_hole=True)
 
 
 class part(OpenSCADObject):
     def __init__(self) -> None:
         super().__init__('part', {})
-        self.set_part_root(True)
+        self.set_part_root(is_root=True)
 
 
 class translate(OpenSCADObject):
@@ -487,7 +487,7 @@ class rotate_extrude(OpenSCADObject):
     The 2D shape needs to be either completely on the positive, or negative
     side (not recommended), of the X axis. It can touch the axis, i.e. zero,
     however if the shape crosses the X axis a warning will be shown in the
-    console windows and the rotate\_extrude() will be ignored. If the shape
+    console windows and the rotate/_extrude() will be ignored. If the shape
     is in the negative axis the faces will be inside-out, you probably don't
     want to do that; it may be fixed in the future.
 

--- a/solid/objects.py
+++ b/solid/objects.py
@@ -803,8 +803,7 @@ def use(scad_file_path: PathStr, use_not_include: bool = True, dest_namespace_di
     try:
         contents = scad_file_path.read_text()
     except Exception as e:
-        raise Exception("Failed to import SCAD module '%(scad_file_path)s' "
-                        "with error: %(e)s " % vars())
+        raise Exception(f"Failed to import SCAD module '{scad_file_path}' with error: {e} ")
 
     # Once we have a list of all callables and arguments, dynamically
     # add OpenSCADObject subclasses for all callables to the calling module's


### PR DESCRIPTION
Hey there,

This is a really great project!   I really appreciate the Type Hinting that was added to it.   :) 

While reading through the code I've done some quick trivial cleanup.  This is just the `objects.py` file.   Each commit should be one cleanup step.  I don't think anything is too controversial here but I thought I would start small.  

The bigger changes that could be a point of discussion are:

- Use `super()` syntax where appropriate : 
  This permits subclassing and more flexible code.  It is functionally the same as `OpenSCADObject.__init__(...` but permits inheritance and the possibility of mixins in the future.  There may be a reason that OpenSCADObject was explicitly being called but I didn't see one.

- Add `-> None` to cls.__init_ calls per PEP484 : 
  My linter was complaining about this.   I've been part of discussions where this seems sort of boilerplate-y but it reduces the amount of ignorable warnings in the type checkers that can hide actual issues.

This project has been really fun to use.  Thanks for all your hard work!
