### PR TITLE
Pep8 examples/

### DIFF
--- a/solid/examples/animation_example.py
+++ b/solid/examples/animation_example.py
@@ -1,12 +1,12 @@
 #! /usr/bin/env python
-# -*- coding: utf-8 -*-
-from __future__ import division
+
 import os
 import sys
+from math import cos, sin
 
-from solid import *
-from solid.utils import *
-from math import sin, cos, radians, degrees
+from solid import scad_render_animated_file
+from solid.objects import square, translate
+
 
 def my_animate(_time=0):
     # _time will range from 0 to 1, not including 1

--- a/solid/examples/animation_example.py
+++ b/solid/examples/animation_example.py
@@ -1,5 +1,4 @@
 #! /usr/bin/env python
-
 import os
 import sys
 from math import cos, sin
@@ -15,6 +14,7 @@ def my_animate(_time=0):
     c = translate([rad * cos(rads), rad * sin(rads)])(square(10))
 
     return c
+
 
 if __name__ == '__main__':
     out_dir = sys.argv[1] if len(sys.argv) > 1 else None
@@ -39,6 +39,4 @@ if __name__ == '__main__':
                                                                   # to the end of the generated
                                                                   # OpenSCAD code.
     print(f"{__file__}: SCAD file written to: \n{file_out}")
-        
 
-    

--- a/solid/examples/animation_example.py
+++ b/solid/examples/animation_example.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 import os
 import sys
 from math import cos, sin

--- a/solid/examples/animation_example.py
+++ b/solid/examples/animation_example.py
@@ -1,12 +1,11 @@
 #! /usr/bin/env python3
-import os
 import sys
 from math import cos, sin
 from typing import Optional
 
 from solid import scad_render_animated_file
-from solid.solidpython import OpenSCADObject
 from solid.objects import square, translate
+from solid.solidpython import OpenSCADObject
 
 
 def my_animate(_time: Optional[float] = 0) -> OpenSCADObject:
@@ -29,16 +28,15 @@ if __name__ == '__main__':
     #       at the bottom of the OpenSCAD window
     # - FPS & Steps are flexible.  For a start, set both to 20 
     #       play around from there      
-    file_out = scad_render_animated_file(my_animate, # A function that takes a float argument
-                                                     # called '_time' in [0,1)
-                                                     # and returns an OpenSCAD object
-                                         steps=20,   # Number of steps to create one complete motion
-                                         back_and_forth=True, # If true, runs the complete motion
-                                                                 # forward and then in reverse,
-                                                                 # to avoid discontinuity
+    file_out = scad_render_animated_file(my_animate,  # A function that takes a float argument
+                                         # called '_time' in [0,1)
+                                         # and returns an OpenSCAD object
+                                         steps=20,  # Number of steps to create one complete motion
+                                         back_and_forth=True,  # If true, runs the complete motion
+                                         # forward and then in reverse,
+                                         # to avoid discontinuity
                                          out_dir=out_dir,
-                                         include_orig_code=True ) # Append SolidPython code
-                                                                  # to the end of the generated
-                                                                  # OpenSCAD code.
+                                         include_orig_code=True)  # Append SolidPython code
+    # to the end of the generated
+    # OpenSCAD code.
     print(f"{__file__}: SCAD file written to: \n{file_out}")
-

--- a/solid/examples/animation_example.py
+++ b/solid/examples/animation_example.py
@@ -2,16 +2,18 @@
 import os
 import sys
 from math import cos, sin
+from typing import Optional
 
 from solid import scad_render_animated_file
+from solid.solidpython import OpenSCADObject
 from solid.objects import square, translate
 
 
-def my_animate(_time=0):
+def my_animate(_time: Optional[float] = 0) -> OpenSCADObject:
     # _time will range from 0 to 1, not including 1
     rads = _time * 2 * 3.1416
     rad = 15
-    c = translate([rad * cos(rads), rad * sin(rads)])(square(10))
+    c = translate((rad * cos(rads), rad * sin(rads)))(square(10))
 
     return c
 

--- a/solid/examples/append_solidpython_code.py
+++ b/solid/examples/append_solidpython_code.py
@@ -1,6 +1,4 @@
 #! /usr/bin/env python3
-# -*- coding: utf-8 -*-
-import os
 import sys
 
 from solid import scad_render_to_file
@@ -25,5 +23,5 @@ if __name__ == '__main__':
     # = bottom of the generated OpenSCAD code, so the final document
     # = contains the easy-to-read python code as well as the SCAD.
     # = ------------------------------------------------------------ =
-    file_out = scad_render_to_file(a, out_dir=out_dir,  include_orig_code=True)
+    file_out = scad_render_to_file(a, out_dir=out_dir, include_orig_code=True)
     print(f"{__file__}: SCAD file written to: \n{file_out}")

--- a/solid/examples/append_solidpython_code.py
+++ b/solid/examples/append_solidpython_code.py
@@ -15,6 +15,7 @@ def show_appended_python_code():
 
     return a
 
+
 if __name__ == '__main__':
     out_dir = sys.argv[1] if len(sys.argv) > 1 else None
     a = show_appended_python_code()

--- a/solid/examples/append_solidpython_code.py
+++ b/solid/examples/append_solidpython_code.py
@@ -3,8 +3,9 @@
 import os
 import sys
 
-from solid import *
-from solid.utils import *
+from solid import scad_render_to_file
+from solid.objects import cylinder
+from solid.utils import up
 
 SEGMENTS = 48
 

--- a/solid/examples/append_solidpython_code.py
+++ b/solid/examples/append_solidpython_code.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 import os
 import sys

--- a/solid/examples/basic_geometry.py
+++ b/solid/examples/basic_geometry.py
@@ -17,10 +17,10 @@ def basic_geometry():
     # left_piece uses standard OpenSCAD grammar (note the commas between
     # block elements; OpenSCAD doesn't require this)
     left_piece =  union()(
-                        translate([-15, 0, 0])(
+                        translate((-15, 0, 0))(
                             cube([10, 5, 3], center=True)
                         ),
-                        translate([-10, 0, 0])(
+                        translate((-10, 0, 0))(
                             difference()(
                                 cylinder(r=5, h=15, center=True),
                                 cylinder(r=4, h=16, center=True)

--- a/solid/examples/basic_geometry.py
+++ b/solid/examples/basic_geometry.py
@@ -16,18 +16,18 @@ def basic_geometry():
 
     # left_piece uses standard OpenSCAD grammar (note the commas between
     # block elements; OpenSCAD doesn't require this)
-    left_piece =  union()(
-                        translate((-15, 0, 0))(
-                            cube([10, 5, 3], center=True)
-                        ),
-                        translate((-10, 0, 0))(
-                            difference()(
-                                cylinder(r=5, h=15, center=True),
-                                cylinder(r=4, h=16, center=True)
-                            )
-                        )
+    left_piece = union()(
+            translate((-15, 0, 0))(
+                    cube([10, 5, 3], center=True)
+            ),
+            translate((-10, 0, 0))(
+                    difference()(
+                            cylinder(r=5, h=15, center=True),
+                            cylinder(r=4, h=16, center=True)
                     )
-    
+            )
+    )
+
     # Right piece uses a more Pythonic grammar.  + (plus) is equivalent to union(), 
     # - (minus) is equivalent to difference() and * (star) is equivalent to intersection
     # solid.utils also defines up(), down(), left(), right(), forward(), and back()
@@ -37,6 +37,7 @@ def basic_geometry():
     right_piece += right(10)(cyl)
 
     return union()(left_piece, right_piece)
+
 
 if __name__ == '__main__':
     out_dir = sys.argv[1] if len(sys.argv) > 1 else None

--- a/solid/examples/basic_geometry.py
+++ b/solid/examples/basic_geometry.py
@@ -1,5 +1,4 @@
 #! /usr/bin/env python
-
 import os
 import sys
 

--- a/solid/examples/basic_geometry.py
+++ b/solid/examples/basic_geometry.py
@@ -1,11 +1,11 @@
 #! /usr/bin/env python
-# -*- coding: utf-8 -*-
-from __future__ import division
+
 import os
 import sys
 
-from solid import *
-from solid.utils import *
+from solid import scad_render_to_file
+from solid.objects import cube, cylinder, difference, translate, union
+from solid.utils import right
 
 SEGMENTS = 48
 

--- a/solid/examples/basic_geometry.py
+++ b/solid/examples/basic_geometry.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 import os
 import sys
 

--- a/solid/examples/basic_geometry.py
+++ b/solid/examples/basic_geometry.py
@@ -1,5 +1,4 @@
 #! /usr/bin/env python3
-import os
 import sys
 
 from solid import scad_render_to_file

--- a/solid/examples/basic_scad_include.py
+++ b/solid/examples/basic_scad_include.py
@@ -22,7 +22,7 @@ def demo_scad_use():
     scad_path = Path(__file__).parent / 'scad_to_include.scad'
     # `This adds the SCAD module `steps()` to the global namespace
     use(scad_path)
-    
+
     return steps(5)
 
 

--- a/solid/examples/basic_scad_include.py
+++ b/solid/examples/basic_scad_include.py
@@ -13,8 +13,7 @@ from solid.objects import import_scad, use
 def demo_import_scad():
     scad_path = Path(__file__).parent / 'scad_to_include.scad'
     scad_mod = import_scad(scad_path)
-    a = scad_mod.steps(5)
-    return a
+    return scad_mod.steps(5)
 
 
 # The `use()` function mimics the behavior of OpenSCAD's use()`
@@ -23,9 +22,8 @@ def demo_scad_use():
     scad_path = Path(__file__).parent / 'scad_to_include.scad'
     # `This adds the SCAD module `steps()` to the global namespace
     use(scad_path)
-
-    a = steps(5)
-    return a
+    
+    return steps(5)
 
 
 if __name__ == '__main__':

--- a/solid/examples/basic_scad_include.py
+++ b/solid/examples/basic_scad_include.py
@@ -17,7 +17,7 @@ def demo_import_scad():
     return a
 
 
-# The `use()` function mimics the bahavior of OpenSCAD's use()`
+# The `use()` function mimics the behavior of OpenSCAD's use()`
 def demo_scad_use():
     # scad_to_include.scad includes a module called steps()
     scad_path = Path(__file__).parent / 'scad_to_include.scad'

--- a/solid/examples/basic_scad_include.py
+++ b/solid/examples/basic_scad_include.py
@@ -3,10 +3,13 @@
 import sys
 from pathlib import Path
 
-from solid import *
+from solid import scad_render_to_file
+from solid.objects import import_scad, use
+
 
 # Import OpenSCAD code and call it from Python code.
 # The path given to use() or import_scad() must be absolute or findable in sys.path
+
 
 def demo_import_scad():
     scad_path = Path(__file__).parent / 'scad_to_include.scad'

--- a/solid/examples/basic_scad_include.py
+++ b/solid/examples/basic_scad_include.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 import sys
 from pathlib import Path
 

--- a/solid/examples/basic_scad_include.py
+++ b/solid/examples/basic_scad_include.py
@@ -1,5 +1,4 @@
 #! /usr/bin/env python
-# -*- coding: utf-8 -*-
 import sys
 from pathlib import Path
 
@@ -17,15 +16,17 @@ def demo_import_scad():
     a = scad_mod.steps(5)
     return a
 
+
 # The `use()` function mimics the bahavior of OpenSCAD's use()`
 def demo_scad_use():
     # scad_to_include.scad includes a module called steps()
     scad_path = Path(__file__).parent / 'scad_to_include.scad'
     # `This adds the SCAD module `steps()` to the global namespace
-    use(scad_path)  
+    use(scad_path)
 
     a = steps(5)
     return a
+
 
 if __name__ == '__main__':
     out_dir = Path(sys.argv[1]) if len(sys.argv) > 1 else None

--- a/solid/examples/bom_scad.py
+++ b/solid/examples/bom_scad.py
@@ -1,5 +1,4 @@
 #! /usr/bin/env python
-# -*- coding: utf-8 -*-
 
 # Basic shape with several repeated parts, demonstrating the use of
 # solid.utils.bill_of_materials()
@@ -38,6 +37,7 @@ doohickey_h = 5
 
 set_bom_headers("link", "leftover")
 
+
 def head():
     return cylinder(h=head_height, r=head_rad)
 
@@ -46,10 +46,10 @@ def head():
 def m3_16(a=3):
     bolt_height = 16
     m = union()(
-        head(),
-        translate([0, 0, -bolt_height])(
-            cylinder(r=m3_rad, h=bolt_height)
-        )
+            head(),
+            translate([0, 0, -bolt_height])(
+                    cylinder(r=m3_rad, h=bolt_height)
+            )
     )
     return m
 
@@ -58,10 +58,10 @@ def m3_16(a=3):
 def m3_12():
     bolt_height = 12
     m = union()(
-        head(),
-        translate([0, 0, -bolt_height])(
-            cylinder(r=m3_rad, h=bolt_height)
-        )
+            head(),
+            translate([0, 0, -bolt_height])(
+                    cylinder(r=m3_rad, h=bolt_height)
+            )
     )
     return m
 
@@ -71,10 +71,10 @@ def m3_nut():
     hx = cylinder(r=nut_rad, h=nut_height)
     hx.add_param('$fn', 6)  # make the nut hexagonal
     n = difference()(
-        hx,
-        translate([0, 0, -EPSILON])(
-            cylinder(r=m3_rad, h=nut_height + 2 * EPSILON)
-        )
+            hx,
+            translate([0, 0, -EPSILON])(
+                    cylinder(r=m3_rad, h=nut_height + 2 * EPSILON)
+            )
     )
     return n
 
@@ -82,28 +82,29 @@ def m3_nut():
 @bom_part()
 def doohickey():
     hole_cyl = translate([0, 0, -EPSILON])(
-        cylinder(r=m3_rad, h=doohickey_h + 2 * EPSILON)
+            cylinder(r=m3_rad, h=doohickey_h + 2 * EPSILON)
     )
     d = difference()(
-        cube([30, 10, doohickey_h], center=True),
-        translate([-10, 0, 0])(hole_cyl),
-        hole_cyl,
-        translate([10, 0, 0])(hole_cyl)
+            cube([30, 10, doohickey_h], center=True),
+            translate([-10, 0, 0])(hole_cyl),
+            hole_cyl,
+            translate([10, 0, 0])(hole_cyl)
     )
     return d
 
 
 def assembly():
     return union()(
-        doohickey(),
-        translate([-10, 0, doohickey_h / 2])(m3_12()),
-        translate([  0, 0, doohickey_h / 2])(m3_16()),
-        translate([ 10, 0, doohickey_h / 2])(m3_12()),
-        # Nuts
-        translate([-10, 0, -nut_height - doohickey_h / 2])(m3_nut()),
-        translate([  0, 0, -nut_height - doohickey_h / 2])(m3_nut()),
-        translate([ 10, 0, -nut_height - doohickey_h / 2])(m3_nut()),
+            doohickey(),
+            translate([-10, 0, doohickey_h / 2])(m3_12()),
+            translate([0, 0, doohickey_h / 2])(m3_16()),
+            translate([10, 0, doohickey_h / 2])(m3_12()),
+            # Nuts
+            translate([-10, 0, -nut_height - doohickey_h / 2])(m3_nut()),
+            translate([0, 0, -nut_height - doohickey_h / 2])(m3_nut()),
+            translate([10, 0, -nut_height - doohickey_h / 2])(m3_nut()),
     )
+
 
 if __name__ == '__main__':
     out_dir = sys.argv[1] if len(sys.argv) > 1 else None

--- a/solid/examples/bom_scad.py
+++ b/solid/examples/bom_scad.py
@@ -17,7 +17,6 @@
 #
 #       -ETJ 08 Mar 2011
 
-import os
 import sys
 
 from solid import scad_render_to_file

--- a/solid/examples/bom_scad.py
+++ b/solid/examples/bom_scad.py
@@ -47,7 +47,7 @@ def m3_16(a=3):
     bolt_height = 16
     m = union()(
             head(),
-            translate([0, 0, -bolt_height])(
+            translate((0, 0, -bolt_height))(
                     cylinder(r=m3_rad, h=bolt_height)
             )
     )
@@ -59,7 +59,7 @@ def m3_12():
     bolt_height = 12
     m = union()(
             head(),
-            translate([0, 0, -bolt_height])(
+            translate((0, 0, -bolt_height))(
                     cylinder(r=m3_rad, h=bolt_height)
             )
     )
@@ -72,7 +72,7 @@ def m3_nut():
     hx.add_param('$fn', 6)  # make the nut hexagonal
     n = difference()(
             hx,
-            translate([0, 0, -EPSILON])(
+            translate((0, 0, -EPSILON))(
                     cylinder(r=m3_rad, h=nut_height + 2 * EPSILON)
             )
     )
@@ -81,14 +81,14 @@ def m3_nut():
 
 @bom_part()
 def doohickey():
-    hole_cyl = translate([0, 0, -EPSILON])(
+    hole_cyl = translate((0, 0, -EPSILON))(
             cylinder(r=m3_rad, h=doohickey_h + 2 * EPSILON)
     )
     d = difference()(
             cube([30, 10, doohickey_h], center=True),
-            translate([-10, 0, 0])(hole_cyl),
+            translate((-10, 0, 0))(hole_cyl),
             hole_cyl,
-            translate([10, 0, 0])(hole_cyl)
+            translate((10, 0, 0))(hole_cyl)
     )
     return d
 
@@ -96,13 +96,13 @@ def doohickey():
 def assembly():
     return union()(
             doohickey(),
-            translate([-10, 0, doohickey_h / 2])(m3_12()),
-            translate([0, 0, doohickey_h / 2])(m3_16()),
-            translate([10, 0, doohickey_h / 2])(m3_12()),
+            translate((-10, 0, doohickey_h / 2))(m3_12()),
+            translate((0, 0, doohickey_h / 2))(m3_16()),
+            translate((10, 0, doohickey_h / 2))(m3_12()),
             # Nuts
-            translate([-10, 0, -nut_height - doohickey_h / 2])(m3_nut()),
-            translate([0, 0, -nut_height - doohickey_h / 2])(m3_nut()),
-            translate([10, 0, -nut_height - doohickey_h / 2])(m3_nut()),
+            translate((-10, 0, -nut_height - doohickey_h / 2))(m3_nut()),
+            translate((0, 0, -nut_height - doohickey_h / 2))(m3_nut()),
+            translate((10, 0, -nut_height - doohickey_h / 2))(m3_nut()),
     )
 
 

--- a/solid/examples/bom_scad.py
+++ b/solid/examples/bom_scad.py
@@ -21,8 +21,10 @@
 import os
 import sys
 
-from solid import *
-from solid.utils import *
+from solid import scad_render_to_file
+from solid.objects import cube, cylinder, difference, translate, union
+from solid.utils import EPSILON
+from solid.utils import bill_of_materials, bom_part, set_bom_headers
 
 head_rad = 2.65
 head_height = 2.8

--- a/solid/examples/bom_scad.py
+++ b/solid/examples/bom_scad.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 # Basic shape with several repeated parts, demonstrating the use of
 # solid.utils.bill_of_materials()

--- a/solid/examples/hole_example.py
+++ b/solid/examples/hole_example.py
@@ -80,6 +80,7 @@ def multipart_hole():
 
     return a
 
+
 if __name__ == '__main__':
     out_dir = sys.argv[1] if len(sys.argv) > 1 else None
 

--- a/solid/examples/hole_example.py
+++ b/solid/examples/hole_example.py
@@ -1,12 +1,10 @@
 #! /usr/bin/env python
-# -*- coding: utf-8 -*-
-from __future__ import division
 import os
 import sys
 
-# Assumes SolidPython is in site-packages or elsewhwere in sys.path
-from solid import *
-from solid.utils import *
+from solid import scad_render_to_file
+from solid.objects import cube, cylinder, hole, part, rotate
+from solid.utils import FORWARD_VEC, right, up
 
 SEGMENTS = 120
 

--- a/solid/examples/hole_example.py
+++ b/solid/examples/hole_example.py
@@ -1,5 +1,4 @@
 #! /usr/bin/env python3
-import os
 import sys
 
 from solid import scad_render_to_file
@@ -92,6 +91,5 @@ if __name__ == '__main__':
     b = up(40)(multipart_hole())
     a += b
 
-    file_out = scad_render_to_file(a, out_dir=out_dir, file_header=f'$fn = {SEGMENTS};',
-                    include_orig_code=True)
+    file_out = scad_render_to_file(a, out_dir=out_dir, file_header=f'$fn = {SEGMENTS};', include_orig_code=True)
     print(f"{__file__}: SCAD file written to: \n{file_out}")

--- a/solid/examples/hole_example.py
+++ b/solid/examples/hole_example.py
@@ -94,6 +94,6 @@ if __name__ == '__main__':
     b = up(40)(multipart_hole())
     a += b
 
-    file_out = scad_render_to_file(a, out_dir=out_dir, file_header=f'$fn = {SEGMENTS};', 
+    file_out = scad_render_to_file(a, out_dir=out_dir, file_header=f'$fn = {SEGMENTS};',
                     include_orig_code=True)
     print(f"{__file__}: SCAD file written to: \n{file_out}")

--- a/solid/examples/hole_example.py
+++ b/solid/examples/hole_example.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 import os
 import sys
 

--- a/solid/examples/hole_example.py
+++ b/solid/examples/hole_example.py
@@ -76,9 +76,7 @@ def multipart_hole():
 
     # The section of the bolt inside not_part disappears.  The section
     # of the bolt inside is_part is still there.
-    a = not_part + bolt + right(45)(is_part + bolt)
-
-    return a
+    return not_part + bolt + right(45)(is_part + bolt)
 
 
 if __name__ == '__main__':

--- a/solid/examples/koch.py
+++ b/solid/examples/koch.py
@@ -8,14 +8,14 @@ from solid import scad_render_to_file
 from solid.objects import polygon, polyhedron, union
 from solid.utils import forward, up
 
-ONE_THIRD = 1 / 3.0
+ONE_THIRD = 1 / 3
 
 
 def affine_combination(a, b, weight=0.5):
-    '''
+    """
     Note that weight is a fraction of the distance between self and other.
-    So... 0.33 is a point .33 of the way between self and other.  
-    '''
+    So... 0.33 is a point .33 of the way between self and other.
+    """
     if hasattr(a, 'z'):
         return Point3((1 - weight) * a.x + weight * b.x,
                       (1 - weight) * a.y + weight * b.y,
@@ -32,12 +32,12 @@ def kochify_3d(a, b, c,
                pyr_a_weight=ONE_THIRD, pyr_b_weight=ONE_THIRD, pyr_c_weight=ONE_THIRD,
                pyr_height_weight=ONE_THIRD
                ):
-    '''
-    Point3s a, b, and c must be coplanar and define a face 
+    """
+    Point3s a, b, and c must be coplanar and define a face
     ab_weight, etc define the subdivision of the original face
     pyr_a_weight, etc define where the point of the new pyramid face will go
     pyr_height determines how far from the face the new pyramid's point will be
-    '''
+    """
     triangles = []
     new_a = affine_combination(a, b, ab_weight)
     new_b = affine_combination(b, c, bc_weight)
@@ -96,8 +96,6 @@ def main_3d(out_dir):
     pyr_b_weight = ONE_THIRD
     pyr_c_weight = ONE_THIRD
     pyr_height_weight = ONE_THIRD
-    pyr_height_weight = ONE_THIRD
-    # pyr_height_weight = .25
 
     all_polys = union()
 
@@ -121,7 +119,6 @@ def main_3d(out_dir):
                                   ab_weight, bc_weight, ca_weight,
                                   pyr_a_weight, pyr_b_weight, pyr_c_weight,
                                   pyr_height_weight)
-            # new_tris = kochify_3d(  a, b, c)
             generations[g].extend(new_tris)
 
     # Put all generations into SCAD
@@ -153,7 +150,6 @@ def main_3d(out_dir):
 
 def main(out_dir):
     # Parameters
-    midpoint_weight = 0.5
     height_ratio = 0.25
     left_loc = ONE_THIRD
     midpoint_loc = 0.5
@@ -177,15 +173,11 @@ def main(out_dir):
         generations.append([])
         for seg in generations[g - 1]:
             generations[g].extend(kochify(seg, height_ratio, left_loc, midpoint_loc, right_loc))
-            # generations[g].extend(kochify(seg))
 
     # # Put all generations into SCAD
     orig_length = abs(generations[0][0])
     for g, a_gen in enumerate(generations):
         points = [s.p1 for s in a_gen]
-        # points.append(a_gen[-1].p2) # add the last point
-
-        rect_offset = 10
 
         # Just use arrays for points so SCAD understands
         points = [[p.x, p.y] for p in points]

--- a/solid/examples/koch.py
+++ b/solid/examples/koch.py
@@ -3,10 +3,11 @@
 import os
 import sys
 
-from solid import *
-from solid.utils import *
+from euclid3 import LineSegment2, LineSegment3, Point2, Point3
 
-from euclid3 import *
+from solid import scad_render_to_file
+from solid.objects import polygon, polyhedron, union
+from solid.utils import forward, up
 
 ONE_THIRD = 1 / 3.0
 

--- a/solid/examples/koch.py
+++ b/solid/examples/koch.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 import os
 import sys
 

--- a/solid/examples/koch.py
+++ b/solid/examples/koch.py
@@ -1,5 +1,4 @@
 #! /usr/bin/env python
-# -*- coding: utf-8 -*-
 import os
 import sys
 
@@ -144,7 +143,7 @@ def main_3d(out_dir):
         all_polys.add(
             up(h)(
                 polyhedron(points=points, faces=faces)
-            )
+        )
         )
 
     file_out = Path(out_dir) / 'koch_3d.scad'
@@ -200,6 +199,7 @@ def main(out_dir):
 
     file_out = scad_render_to_file(all_polys, out_dir=out_dir, include_orig_code=True)
     print(f"{__file__}: SCAD file written to: {file_out}")
+
 
 if __name__ == '__main__':
     out_dir = sys.argv[1] if len(sys.argv) > 1 else None

--- a/solid/examples/koch.py
+++ b/solid/examples/koch.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python3
-import os
 import sys
+from pathlib import Path
 
 from euclid3 import LineSegment2, LineSegment3, Point2, Point3
 
@@ -138,9 +138,9 @@ def main_3d(out_dir):
         # Do the SCAD
         edges = [list(range(len(points)))]
         all_polys.add(
-            up(h)(
-                polyhedron(points=points, faces=faces)
-        )
+                up(h)(
+                        polyhedron(points=points, faces=faces)
+                )
         )
 
     file_out = Path(out_dir) / 'koch_3d.scad'

--- a/solid/examples/mazebox/inset.py
+++ b/solid/examples/mazebox/inset.py
@@ -1,5 +1,6 @@
 from math import sqrt
 
+
 class Vec2D:
 
     def __init__(self, x, y):
@@ -71,6 +72,7 @@ class MetaCADLine:
 def det(a, b, c, d):
     return a * d - b * c
 
+
 # solves system of 2 linear equations in 2 unknown
 
 
@@ -122,7 +124,7 @@ def insetPoly(poly, inset):
             diff = newLine.normal.minus(oldnorm).len()
             if (diff > 0.1):
                 pass
-                #print("error inverting")
+                # print("error inverting")
                 # exit()
             else:
                 pass
@@ -137,7 +139,7 @@ def insetPoly(poly, inset):
         newLine = MetaCADLine(asVec2D(points[iprev]), asVec2D(points[i]))
         diff = newLine.normal.minus(oldnorm).len()
         if (diff > 0.1):
-            #print("wrong dir detected")
+            # print("wrong dir detected")
             if (istart == -1):
                 istart = i
                 ilen = 1
@@ -147,16 +149,16 @@ def insetPoly(poly, inset):
             if (ilen > 0):
                 if (istart == 0):
                     pass
-                    #print("oh noes")
+                    # print("oh noes")
                     # exit()
                 else:
-                    #print("trying to save: ", istart, i)
+                    # print("trying to save: ", istart, i)
                     idxs = (len(poly) + istart - 1) % len(poly)
                     idxe = (i) % len(poly)
                     p1 = points[idxs]
                     p2 = points[idxe]
-                    #points[idxs] = p2
-                    #points[idxe] = p1
+                    # points[idxs] = p2
+                    # points[idxe] = p1
                     for j in range(istart, i):
                         t = float(1 + j - istart) / (1 + i - istart)
                         # print(t)

--- a/solid/examples/mazebox/inset.py
+++ b/solid/examples/mazebox/inset.py
@@ -77,7 +77,7 @@ def det(a, b, c, d):
 
 
 class LinearSolve2:
-    # the equations look like thsi looks like this
+    # the equations look like this looks like this
     # x1*a + x2*b = r1
     # x1*c + x2*d = r2
 

--- a/solid/examples/mazebox/inset.py
+++ b/solid/examples/mazebox/inset.py
@@ -1,6 +1,4 @@
-from math import *
-from trianglemath import *
-
+from math import sqrt
 
 class Vec2D:
 

--- a/solid/examples/mazebox/mazebox.py
+++ b/solid/examples/mazebox/mazebox.py
@@ -20,7 +20,7 @@ from .trianglemath import Tripple2Vec3D, angleBetweenPlanes
 SEGMENTS = 48
 
 rn = 3 * 64
-#r = 10
+# r = 10
 innerR = 25
 gap = 0.5
 wall = 1.50
@@ -33,6 +33,7 @@ h = hn * s
 hone = h / hn
 
 toph = (h - gripH) + 3
+
 
 def getPNG(fn):
     with open(fn, 'rb') as f:
@@ -50,6 +51,7 @@ def getPNG(fn):
                 r.append(px)
         return raw
 
+
 def build_depth_map(img_path):
     depth = []
     for i in range(0, hn):
@@ -58,6 +60,7 @@ def build_depth_map(img_path):
     depth = getPNG(img_path)
     depth.reverse()
     return depth
+
 
 def getPx(depth_map, x, y, default):
     x = int(x)
@@ -69,6 +72,7 @@ def getPx(depth_map, x, y, default):
         return depth_map[y][x]
     return default
 
+
 def myComp(x, y):
     d = Tripple2Vec3D(y).angle2D() - Tripple2Vec3D(x).angle2D()
     if (d < 0):
@@ -78,8 +82,8 @@ def myComp(x, y):
     else:
         return 1
 
-def bumpMapCylinder(depth_map, theR, hn, inset, default):
 
+def bumpMapCylinder(depth_map, theR, hn, inset, default):
     pts = []
     trls = []
     for i in range(0, hn):
@@ -90,13 +94,13 @@ def bumpMapCylinder(depth_map, theR, hn, inset, default):
             p = [r * cos(a), r * sin(a), i * hone]
             circ.append(p)
         circ = insetPoly(circ, inset)
-        #circ.sort(lambda x, y: -1 if (Tripple2Vec3D(y).angle2D() - Tripple2Vec3D(x).angle2D() < 0) else 1)
+        # circ.sort(lambda x, y: -1 if (Tripple2Vec3D(y).angle2D() - Tripple2Vec3D(x).angle2D() < 0) else 1)
         aold = Tripple2Vec3D(circ[0]).angle2D()
         for c in circ:
             a = Tripple2Vec3D(c).angle2D()
             # print(a)
             if (a > aold and (abs(a - aold) < 1 * pi)):
-                #print(a, aold)
+                # print(a, aold)
                 # exit()
                 pass
             aold = a
@@ -119,7 +123,7 @@ def bumpMapCylinder(depth_map, theR, hn, inset, default):
             a1 = min(a1, pi - a1)
             a2 = angleBetweenPlanes([pts[p2], pts[p1], pts[p4]], [pts[p2], pts[p3], pts[p4]])
             a2 = min(a2, pi - a2)
-            #print(a1, a2)
+            # print(a1, a2)
             if (a1 < a2):
                 t = [p1, p2, p3]
                 trls.append(t)
@@ -133,6 +137,7 @@ def bumpMapCylinder(depth_map, theR, hn, inset, default):
 
     return polyhedron(pts, trls, 6)
 
+
 def top_part():
     maze_path = os.path.join(os.path.dirname(__file__), 'maze7.png')
 
@@ -143,16 +148,17 @@ def top_part():
     u.add(bumpMapCylinder(depth_map, innerR, hn, 0, 255))
     u.add(cylinder(r=innerR + wall + gap, h=gripH))
     d.add(u)
-    #u.add(translate([80,0,0]).add(bumpMapCylinder(depth_map, innerR, wall)))
+    # u.add(translate([80,0,0]).add(bumpMapCylinder(depth_map, innerR, wall)))
     d.add(intersection()
-    .add(bumpMapCylinder(depth_map, innerR, hn + 2, wall, 0).set_modifier("") )
-    .add(translate([0, 0, baseH])
-    .add(cylinder(r=innerR + 2 * wall, h=h * 1.1).set_modifier(""))))
+          .add(bumpMapCylinder(depth_map, innerR, hn + 2, wall, 0).set_modifier(""))
+          .add(translate([0, 0, baseH])
+               .add(cylinder(r=innerR + 2 * wall, h=h * 1.1).set_modifier(""))))
 
     # u.add()
     # print("$fa=2; $fs=0.5;\n")
     # print(d._render())
     return d
+
 
 def bottom_part():
     top = difference()
@@ -172,15 +178,16 @@ def bottom_part():
 
     return top
 
+
 if __name__ == '__main__':
     out_dir = sys.argv[1] if len(sys.argv) > 1 else None
     file_out = os.path.join(out_dir, 'mazebox.scad')
 
     assm = union()(
-        top_part(),
-        translate([3*innerR, 0,0])(
-            bottom_part()
-        )
+            top_part(),
+            translate([3 * innerR, 0, 0])(
+                    bottom_part()
+            )
     )
 
     print(f"{__file__}: SCAD file written to: \n{file_out}")

--- a/solid/examples/mazebox/mazebox.py
+++ b/solid/examples/mazebox/mazebox.py
@@ -151,7 +151,7 @@ def top_part():
     # u.add(translate([80,0,0]).add(bumpMapCylinder(depth_map, innerR, wall)))
     d.add(intersection()
           .add(bumpMapCylinder(depth_map, innerR, hn + 2, wall, 0).set_modifier(""))
-          .add(translate([0, 0, baseH])
+          .add(translate((0, 0, baseH))
                .add(cylinder(r=innerR + 2 * wall, h=h * 1.1).set_modifier(""))))
 
     # u.add()
@@ -167,14 +167,14 @@ def bottom_part():
     top.add(u)
     d = difference()
     d.add(cylinder(r=innerR + wall + gap, h=toph))
-    d.add(translate([0, 0, baseH]).add(cylinder(r=innerR + gap, h=toph)))
+    d.add(translate((0, 0, baseH)).add(cylinder(r=innerR + gap, h=toph)))
     u.add(d)
     top.add(u2)
     for i in range(0, 3):
         a = i * 2 * pi / 3.0
         r = innerR + gap + wall / 2
-        u.add(translate([(r - 0.3) * cos(a), (r - 0.3) * sin(a), toph - 6]).add(sphere(r=2.4)))
-        u2.add(translate([(r + wall - 0.3) * cos(a), (r + wall - 0.3) * sin(a), toph - 6]).add(sphere(r=2.4)))
+        u.add(translate(((r - 0.3) * cos(a), (r - 0.3) * sin(a), toph - 6)).add(sphere(r=2.4)))
+        u2.add(translate(((r + wall - 0.3) * cos(a), (r + wall - 0.3) * sin(a), toph - 6)).add(sphere(r=2.4)))
 
     return top
 
@@ -185,7 +185,7 @@ if __name__ == '__main__':
 
     assm = union()(
             top_part(),
-            translate([3 * innerR, 0, 0])(
+            translate((3 * innerR, 0, 0))(
                     bottom_part()
             )
     )

--- a/solid/examples/mazebox/mazebox.py
+++ b/solid/examples/mazebox/mazebox.py
@@ -153,7 +153,7 @@ def bottom_part():
     u.add(d)
     top.add(u2)
     for i in range(0, 3):
-        a = i * 2 * pi / 3.0
+        a = i * 2 * pi / 3
         r = innerR + gap + wall / 2
         u.add(translate(((r - 0.3) * cos(a), (r - 0.3) * sin(a), toph - 6)).add(sphere(r=2.4)))
         u2.add(translate(((r + wall - 0.3) * cos(a), (r + wall - 0.3) * sin(a), toph - 6)).add(sphere(r=2.4)))

--- a/solid/examples/mazebox/mazebox.py
+++ b/solid/examples/mazebox/mazebox.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 #   A-Mazing Box, http://www.thingiverse.com/thing:1481
 #   Copyright (C) 2009    Philipp Tiefenbacher <wizards23@gmail.com>

--- a/solid/examples/mazebox/mazebox.py
+++ b/solid/examples/mazebox/mazebox.py
@@ -1,5 +1,4 @@
 #! /usr/bin/env python
-# -*- coding: utf-8 -*-
 
 #   A-Mazing Box, http://www.thingiverse.com/thing:1481
 #   Copyright (C) 2009    Philipp Tiefenbacher <wizards23@gmail.com>
@@ -7,15 +6,16 @@
 #   With further changes for clarity, 25 September 2018
 #
 
-import sys
 import os
-
-from math import *
-from solid import *
+import sys
+from math import cos, pi, sin
 
 import png
-from inset import *
-from trianglemath import *
+
+from solid import scad_render_to_file
+from solid.objects import cylinder, difference, intersection, polyhedron, sphere, translate, union
+from .inset import insetPoly
+from .trianglemath import Tripple2Vec3D, angleBetweenPlanes
 
 SEGMENTS = 48
 

--- a/solid/examples/mazebox/mazebox.py
+++ b/solid/examples/mazebox/mazebox.py
@@ -14,8 +14,8 @@ import png
 
 from solid import scad_render_to_file
 from solid.objects import cylinder, difference, intersection, polyhedron, sphere, translate, union
-from .inset import insetPoly
-from .trianglemath import Tripple2Vec3D, angleBetweenPlanes
+from inset import insetPoly
+from trianglemath import Tripple2Vec3D, angleBetweenPlanes
 
 SEGMENTS = 48
 

--- a/solid/examples/mazebox/mazebox.py
+++ b/solid/examples/mazebox/mazebox.py
@@ -41,10 +41,7 @@ def getPNG(fn):
         data = r.read()
         pixel = data[2]
         raw = []
-        # print(data)
         for row in pixel:
-            # print(row)
-            # exit()
             r = []
             raw.append(r)
             for px in row:
@@ -65,56 +62,47 @@ def build_depth_map(img_path):
 def getPx(depth_map, x, y, default):
     x = int(x)
     y = int(y)
-    x = x % len(depth_map[0])
-    if (y >= len(depth_map)):
+    x %= len(depth_map[0])
+    if y >= len(depth_map):
         y = len(depth_map) - 1
-    if (x >= 0 and x < len(depth_map[0]) and y >= 0 and y < len(depth_map)):
+    if 0 <= x < len(depth_map[0]) and 0 <= y < len(depth_map):
         return depth_map[y][x]
     return default
 
 
 def myComp(x, y):
     d = Tripple2Vec3D(y).angle2D() - Tripple2Vec3D(x).angle2D()
-    if (d < 0):
+    if d < 0:
         return -1
-    elif (d == 0):
+    elif d == 0:
         return 0
     else:
         return 1
 
 
-def bumpMapCylinder(depth_map, theR, hn, inset, default):
+def bumpMapCylinder(depth_map, the_r, hn_, inset, default):
     pts = []
     trls = []
-    for i in range(0, hn):
+    for i in range(hn_):
         circ = []
-        for j in range(0, rn):
+        for j in range(rn):
             a = j * 2 * pi / rn
-            r = theR - ((255 - getPx(depth_map, j, i, default)) / 150.0)
+            r = the_r - ((255 - getPx(depth_map, j, i, default)) / 150)
             p = [r * cos(a), r * sin(a), i * hone]
             circ.append(p)
         circ = insetPoly(circ, inset)
-        # circ.sort(lambda x, y: -1 if (Tripple2Vec3D(y).angle2D() - Tripple2Vec3D(x).angle2D() < 0) else 1)
-        aold = Tripple2Vec3D(circ[0]).angle2D()
         for c in circ:
-            a = Tripple2Vec3D(c).angle2D()
-            # print(a)
-            if (a > aold and (abs(a - aold) < 1 * pi)):
-                # print(a, aold)
-                # exit()
-                pass
-            aold = a
             pts.append(c)
 
     pts.append([0, 0, 0])
     pts.append([0, 0, i * hone])
 
-    for j in range(0, rn):
-        t = [j, (j + 1) % rn, rn * hn]
+    for j in range(rn):
+        t = [j, (j + 1) % rn, rn * hn_]
         trls.append(t)
-        t = [(rn * hn - 1) - j, (rn * hn - 1) - ((j + 1) % rn), rn * hn + 1]
+        t = [(rn * hn_ - 1) - j, (rn * hn_ - 1) - ((j + 1) % rn), rn * hn_ + 1]
         trls.append(t)
-        for i in range(0, hn - 1):
+        for i in range(0, hn_ - 1):
             p1 = i * rn + ((j + 1) % rn)
             p2 = i * rn + j
             p3 = (i + 1) * rn + j
@@ -123,8 +111,7 @@ def bumpMapCylinder(depth_map, theR, hn, inset, default):
             a1 = min(a1, pi - a1)
             a2 = angleBetweenPlanes([pts[p2], pts[p1], pts[p4]], [pts[p2], pts[p3], pts[p4]])
             a2 = min(a2, pi - a2)
-            # print(a1, a2)
-            if (a1 < a2):
+            if a1 < a2:
                 t = [p1, p2, p3]
                 trls.append(t)
                 t = [p4, p1, p3]
@@ -148,15 +135,10 @@ def top_part():
     u.add(bumpMapCylinder(depth_map, innerR, hn, 0, 255))
     u.add(cylinder(r=innerR + wall + gap, h=gripH))
     d.add(u)
-    # u.add(translate([80,0,0]).add(bumpMapCylinder(depth_map, innerR, wall)))
     d.add(intersection()
           .add(bumpMapCylinder(depth_map, innerR, hn + 2, wall, 0).set_modifier(""))
           .add(translate((0, 0, baseH))
                .add(cylinder(r=innerR + 2 * wall, h=h * 1.1).set_modifier(""))))
-
-    # u.add()
-    # print("$fa=2; $fs=0.5;\n")
-    # print(d._render())
     return d
 
 
@@ -191,4 +173,4 @@ if __name__ == '__main__':
     )
 
     print(f"{__file__}: SCAD file written to: \n{file_out}")
-    scad_render_to_file(assm, file_out, file_header=f'$fn = {SEGMENTS};', include_orig_code=True)
+    scad_render_to_file(assm, file_out, file_header=f'$fn = {SEGMENTS};')

--- a/solid/examples/mazebox/trianglemath.py
+++ b/solid/examples/mazebox/trianglemath.py
@@ -1,4 +1,4 @@
-from math import *
+from math import acos, atan2, pi, sqrt
 
 
 def Tripple2Vec3D(t):

--- a/solid/examples/mazebox/trianglemath.py
+++ b/solid/examples/mazebox/trianglemath.py
@@ -24,7 +24,7 @@ class Vec3D:
     def times(self, t):
         return Vec3D(self.x * t, self.y * t, self.z * t)
 
-    # changes the objetct itself
+    # changes the object itself
     def add(self, v):
         self.x += v.x
         self.y += v.y

--- a/solid/examples/mazebox/trianglemath.py
+++ b/solid/examples/mazebox/trianglemath.py
@@ -8,11 +8,13 @@ def Tripple2Vec3D(t):
 class Vec3D:
 
     def __init__(self, x, y, z):
-        self.set(x, y, z)
+        self.x = x
+        self.y = y
+        self.z = z
 
     def angle2D(self):
         a = atan2(self.x, self.y)
-        if (a < 0):
+        if a < 0:
             a += 2 * pi
         return a
 
@@ -73,12 +75,10 @@ def angleBetweenPlanes(p1, p2):
     n2 = planeNormal(p2)
     n1.normalize()
     n2.normalize()
-    # print(n1.asTripple())
-    # print(n2.asTripple())
+
     s = n1.scalarProduct(n2)
-    # print(s)
-    if (s > 1):
+    if s > 1:
         s = 1
-    if (s < -1):
+    if s < -1:
         s = -1
     return acos(s)

--- a/solid/examples/path_extrude_example.py
+++ b/solid/examples/path_extrude_example.py
@@ -1,5 +1,4 @@
 #! /usr/bin/env python3
-import os
 import sys
 from math import cos, radians, sin
 

--- a/solid/examples/path_extrude_example.py
+++ b/solid/examples/path_extrude_example.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 import os
 import sys
 from math import cos, radians, sin

--- a/solid/examples/path_extrude_example.py
+++ b/solid/examples/path_extrude_example.py
@@ -1,13 +1,12 @@
 #! /usr/bin/env python
-# -*- coding: utf-8 -*-
-from __future__ import division
 import os
 import sys
+from math import cos, radians, sin
 
-# Assumes SolidPython is in site-packages or elsewhwere in sys.path
-from solid import *
-from solid.utils import *
-from math import sin, cos, radians, degrees
+from euclid3 import Point3
+
+from solid import scad_render_to_file
+from solid.utils import extrude_along_path
 
 SEGMENTS = 48
 

--- a/solid/examples/path_extrude_example.py
+++ b/solid/examples/path_extrude_example.py
@@ -32,7 +32,6 @@ def star(num_points=5, outer_rad=15, dip_factor=0.5):
 
 
 def extrude_example():
-
     # Note the incorrect triangulation at the two ends of the path.  This
     # is because star isn't convex, and the triangulation algorithm for
     # the two end caps only works for convex shapes.
@@ -49,6 +48,7 @@ def extrude_example():
     extruded = extrude_along_path(shape_pts=shape, path_pts=path, scale_factors=scales)
 
     return extruded
+
 
 if __name__ == '__main__':
     out_dir = sys.argv[1] if len(sys.argv) > 1 else None

--- a/solid/examples/run_all_examples.sh
+++ b/solid/examples/run_all_examples.sh
@@ -14,12 +14,12 @@ fi
  
  function run_example {
     echo "===================================================";
-    python "$1 $2";
+    python "$1" "$2";
     echo "===================================================";
 }
 
 for py in *.py;
-do run_example "$py $COMPILED_EXAMPLES";
+do run_example "$py" "$COMPILED_EXAMPLES";
 done 
 
 run_example mazebox/mazebox.py "$COMPILED_EXAMPLES";

--- a/solid/examples/run_all_examples.sh
+++ b/solid/examples/run_all_examples.sh
@@ -1,28 +1,28 @@
 #!/usr/bin/env bash
 
 # Set CWD to this script's directory
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 cd "$DIR" || exit 1
 
 COMPILED_EXAMPLES=${PWD}/Compiled_examples
 
 echo
 # if COMPILED_EXAMPLES doesn't exist, create it.
-if [ ! -e "$COMPILED_EXAMPLES" ];
-     then mkdir "$COMPILED_EXAMPLES";
-fi    
- 
- function run_example {
-    echo "===================================================";
-    python "$1" "$2";
-    echo "===================================================";
+if [ ! -e "$COMPILED_EXAMPLES" ]; then
+  mkdir "$COMPILED_EXAMPLES"
+fi
+
+function run_example() {
+  echo "==================================================="
+  python "$1" "$2"
+  echo "==================================================="
 }
 
-for py in *.py;
-do run_example "$py" "$COMPILED_EXAMPLES";
-done 
+for py in *.py; do
+  run_example "$py" "$COMPILED_EXAMPLES"
+done
 
-run_example mazebox/mazebox.py "$COMPILED_EXAMPLES";
+run_example mazebox/mazebox.py "$COMPILED_EXAMPLES"
 
 # revert to original dir
 cd - || exit 1

--- a/solid/examples/run_all_examples.sh
+++ b/solid/examples/run_all_examples.sh
@@ -2,28 +2,27 @@
 
 # Set CWD to this script's directory
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-cd $DIR
+cd "$DIR" || exit 1
 
 COMPILED_EXAMPLES=${PWD}/Compiled_examples
 
 echo
 # if COMPILED_EXAMPLES doesn't exist, create it.
-if [ ! -e $COMPILED_EXAMPLES ]; 
-     then mkdir $COMPILED_EXAMPLES;     
+if [ ! -e "$COMPILED_EXAMPLES" ];
+     then mkdir "$COMPILED_EXAMPLES";
 fi    
  
  function run_example {
     echo "===================================================";
-    # echo "python $1 $2";
-    python $1 $2;  
+    python "$1 $2";
     echo "===================================================";
 }
 
 for py in *.py;
-do run_example $py $COMPILED_EXAMPLES;
+do run_example "$py $COMPILED_EXAMPLES";
 done 
 
-run_example mazebox/mazebox.py $COMPILED_EXAMPLES;
+run_example mazebox/mazebox.py "$COMPILED_EXAMPLES";
 
 # revert to original dir
-cd -
+cd - || exit 1

--- a/solid/examples/screw_thread_example.py
+++ b/solid/examples/screw_thread_example.py
@@ -1,12 +1,11 @@
 #! /usr/bin/env python
-# -*- coding: utf-8 -*-
-from __future__ import division
+
 import os
 import sys
 
-from solid import *
-from solid.utils import *
+from solid import scad_render_to_file
 from solid import screw_thread
+from solid.objects import cylinder
 
 SEGMENTS = 48
 

--- a/solid/examples/screw_thread_example.py
+++ b/solid/examples/screw_thread_example.py
@@ -1,5 +1,4 @@
 #! /usr/bin/env python3
-import os
 import sys
 
 from solid import scad_render_to_file
@@ -29,5 +28,5 @@ def assembly():
 if __name__ == '__main__':
     out_dir = sys.argv[1] if len(sys.argv) > 1 else None
     a = assembly()
-    file_out = scad_render_to_file(a, out_dir = out_dir, include_orig_code=True)
+    file_out = scad_render_to_file(a, out_dir=out_dir, include_orig_code=True)
     print(f"{__file__}: SCAD file written to: \n{file_out}")

--- a/solid/examples/screw_thread_example.py
+++ b/solid/examples/screw_thread_example.py
@@ -1,5 +1,4 @@
 #! /usr/bin/env python
-
 import os
 import sys
 
@@ -15,16 +14,17 @@ screw_height = 80
 
 def assembly():
     section = screw_thread.default_thread_section(tooth_height=10, tooth_depth=5)
-    s = screw_thread.thread(outline_pts=section, 
+    s = screw_thread.thread(outline_pts=section,
                             inner_rad=inner_rad,
-                            pitch=screw_height, 
-                            length=screw_height, 
-                            segments_per_rot=SEGMENTS, 
-                            neck_in_degrees=90, 
+                            pitch=screw_height,
+                            length=screw_height,
+                            segments_per_rot=SEGMENTS,
+                            neck_in_degrees=90,
                             neck_out_degrees=90)
 
     c = cylinder(r=inner_rad, h=screw_height)
     return s + c
+
 
 if __name__ == '__main__':
     out_dir = sys.argv[1] if len(sys.argv) > 1 else None

--- a/solid/examples/screw_thread_example.py
+++ b/solid/examples/screw_thread_example.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 import os
 import sys
 

--- a/solid/examples/sierpinski.py
+++ b/solid/examples/sierpinski.py
@@ -67,10 +67,10 @@ def weighted_midpoint(a, b, weight=0.5, jitter_range_vec=None):
 
 
 def sierpinski_3d(generation, scale=1, midpoint_weight=0.5, jitter_range_vec=None):
-    orig_tet = SierpinskiTetrahedron([[ 1.0,  1.0,  1.0],
-                                      [-1.0, -1.0,  1.0],
-                                      [-1.0,  1.0, -1.0],
-                                      [ 1.0, -1.0, -1.0]])
+    orig_tet = SierpinskiTetrahedron([[1.0, 1.0, 1.0],
+                                      [-1.0, -1.0, 1.0],
+                                      [-1.0, 1.0, -1.0],
+                                      [1.0, -1.0, -1.0]])
     all_tets = [orig_tet]
     for i in range(generation):
         all_tets = [subtet for tet in all_tets for subtet in tet.next_gen(midpoint_weight, jitter_range_vec)]

--- a/solid/examples/sierpinski.py
+++ b/solid/examples/sierpinski.py
@@ -1,8 +1,8 @@
 #! /usr/bin/env python3
 import math
-import os
 import random
 import sys
+from pathlib import Path
 
 from solid import scad_render_to_file
 from solid.objects import cube, polyhedron, translate, union

--- a/solid/examples/sierpinski.py
+++ b/solid/examples/sierpinski.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 import math
 import os
 import random

--- a/solid/examples/sierpinski.py
+++ b/solid/examples/sierpinski.py
@@ -1,13 +1,12 @@
 #! /usr/bin/env python
-# -*- coding: utf-8 -*-
+import math
 import os
+import random
 import sys
 
-from solid import *
-from solid.utils import *
+from solid import scad_render_to_file
+from solid.objects import cube, polyhedron, translate, union
 
-import random
-import math
 
 # =========================================================
 # = A basic recursive Sierpinski's gasket implementation,

--- a/solid/examples/solidpython_template.py
+++ b/solid/examples/solidpython_template.py
@@ -11,6 +11,7 @@ def assembly():
 
     return a
 
+
 if __name__ == '__main__':
     a = assembly()
     scad_render_to_file(a, file_header=f'$fn = {SEGMENTS};', include_orig_code=True)

--- a/solid/examples/solidpython_template.py
+++ b/solid/examples/solidpython_template.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 from solid import scad_render_to_file
 from solid.objects import union
 

--- a/solid/examples/solidpython_template.py
+++ b/solid/examples/solidpython_template.py
@@ -1,12 +1,6 @@
 #! /usr/bin/env python
-# -*- coding: utf-8 -*-
-from __future__ import division
-import os
-import sys
-
-# Assumes SolidPython is in site-packages or elsewhwere in sys.path
-from solid import *
-from solid.utils import *
+from solid import scad_render_to_file
+from solid.objects import union
 
 SEGMENTS = 48
 


### PR DESCRIPTION
This is a cleanup of the code in the `examples/` dir.  The primary goal was removing the `import *` pattern and removing cruft that might confuse a new user.  I am aware of #114.  I believe the desire for clarity is maintained here without the negative consequences of namespace pollution.

I noticed that there were some type hinting issues around `translate()` and `extrude_along_path()`.    The code seems to function so it is probably too restrictive typing or incorrect assumptions about the args.   

Again like my other PRs these commits should be broken into general themes.  e950c53 converts some lists to tuples and should only leave the typing issues I mentioned above.

I love all these examples and it has made the code a lot more understandable.  Thank you for including these.  :)
