### PR TITLE
Add basic hash() and comparison support

### DIFF
--- a/solid/solidpython.py
+++ b/solid/solidpython.py
@@ -353,6 +353,12 @@ class OpenSCADObject:
 
         return png_data
 
+    def __hash__(self):
+        return hash(self._render(render_holes=True))
+
+    def __eq__(self, other):
+        return self._render(render_holes=True) == other._render(render_holes=True)
+
 
 class IncludedOpenSCADObject(OpenSCADObject):
     """


### PR DESCRIPTION
I want to use objs as keys in a dictionary, so that I can count the number of different geometries.
Think something like this:

```py
part_counter = defaultdict(int)
for part in parts:
    part_counter[part] += 1
```

For this I just added a very basic hashing and comparison support based on the text output of the render. I don't know enough about the code to implement caching, since I'm not sure how to invalidate the cache.

Background: I'm working on [1:32 railway signals](http://salkinium.com/elva/signal) and use SolidPython to generate the [3D printed signal masks](https://pbs.twimg.com/media/EdLaLBXX0AAZRSM?format=jpg&name=4096x4096) and [optics](https://pbs.twimg.com/media/EdLaLD_XoAAfEOO?format=jpg&name=4096x4096) using inputs from KiCAD PCBs and a custom build system. I use the dictionary trick to aggregate the number of different optics per signal mask to build a panel for 3D printing.

Cc @etjones