### PR TITLE
Provide ~ debug helper (like OpenSCAD #)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -286,6 +286,24 @@ is the same as:
         cylinder(r=2, h=30)
     )
 
+To assist with debugging:
+
+.. code:: python
+
+    c = ~cylinder(r=10, h=5)
+
+is the same as:
+
+.. code:: python
+
+    c = cylinder(r=10, h=5).set_modifier("#")
+
+which in OpenSCAD would be:
+
+.. code:: openscad
+
+    #cylinder(r=10, h=5)
+
 First-class Negative Space (Holes)
 ----------------------------------
 

--- a/solid/solidpython.py
+++ b/solid/solidpython.py
@@ -304,6 +304,12 @@ class OpenSCADObject:
         """
         return self.add(args)
 
+    def __invert__(self):
+        """
+        Same as .set_modifier("#")
+        """
+        return self.set_modifier("#")
+
     def __add__(self, x: "OpenSCADObject") -> "OpenSCADObject":
         """
         This makes u = a+b identical to:


### PR DESCRIPTION
Provide a `~` helper - when prefixed on an object is the same as `.set_modifier("#")` - or a `#` prefix in OpenSCAD. I have been using this patch for some time now for my own use and find it extremely useful.