### PR TITLE
fix OpenSCAD identifiers starting with a digit

### DIFF
--- a/solid/solidpython.py
+++ b/solid/solidpython.py
@@ -739,9 +739,17 @@ def new_openscad_class_str(class_name: str,
 def _subbed_keyword(keyword: str) -> str:
     """
     Append an underscore to any python reserved word.
+    Prepend an underscore to any OpenSCAD identifier starting with a digit.
     No-op for all other strings, e.g. 'or' => 'or_', 'other' => 'other'
     """
-    new_key = keyword + '_' if keyword in PYTHON_ONLY_RESERVED_WORDS else keyword
+    new_key = keyword
+
+    if keyword in PYTHON_ONLY_RESERVED_WORDS:
+        new_key = keyword + "_"
+
+    if keyword[0].isdigit():
+        new_key = "_" + keyword
+
     if new_key != keyword:
         print(f"\nFound OpenSCAD code that's not compatible with Python. \n"
               f"Imported OpenSCAD code using `{keyword}` \n"
@@ -751,10 +759,16 @@ def _subbed_keyword(keyword: str) -> str:
 def _unsubbed_keyword(subbed_keyword: str) -> str:
     """
     Remove trailing underscore for already-subbed python reserved words.
+    Remove prepending underscore if remaining identifier starts with a digit.
     No-op for all other strings: e.g. 'or_' => 'or', 'other_' => 'other_'
     """
-    shortened = subbed_keyword[:-1]
-    return shortened if shortened in PYTHON_ONLY_RESERVED_WORDS else subbed_keyword
+    if subbed_keyword.endswith("_") and subbed_keyword[:-1] in PYTHON_ONLY_RESERVED_WORDS:
+        return subbed_keyword[:-1]
+
+    if subbed_keyword.startswith("_") and subbed_keyword[1].isdigit():
+        return subbed_keyword[1:]
+
+    return subbed_keyword
 
 # now that we have the base class defined, we can do a circular import
 from . import objects


### PR DESCRIPTION
This patch fixes half of  #166 caused by OpenSCAD identifier starting with a digit