### PR TITLE
Allow generating the shape dynamically, along the extrusion path

### DIFF
--- a/solid/extrude_along_path.py
+++ b/solid/extrude_along_path.py
@@ -56,12 +56,15 @@ def extrude_along_path( shape_pts:Points,
     facet_indices:List[Tuple[int, int, int]] = []
 
     # Make sure we've got Euclid Point3's for all elements
-    shape_pts = euclidify(shape_pts, Point3)
     path_pts = euclidify(path_pts, Point3)
 
     src_up = Vector3(0, 0, 1)
 
-    shape_pt_count = len(shape_pts)
+    if callable(shape_pts):
+        shape_pt_count = None
+    else: 
+        shape_pts = euclidify(shape_pts, Point3)
+        shape_pt_count = len(shape_pts)
 
     tangent_path_points: List[Point3] = []
     if connect_ends:
@@ -88,7 +91,15 @@ def extrude_along_path( shape_pts:Points,
         if transforms:
             transform_func = transforms[which_loop] if len(transforms) > 1 else transforms[0]
 
-        this_loop = shape_pts[:]
+        if callable(shape_pts):
+            this_loop = shape_pts(which_loop/len(path_pts))
+            if shape_pt_count is None:
+                shape_pt_count = len(this_loop)
+            else:
+                assert len(this_loop) == shape_pt_count
+        else:
+            this_loop = shape_pts[:]
+
         this_loop = _scale_loop(this_loop, scale)
         this_loop = _rotate_loop(this_loop, rotate_degrees)
         this_loop = _transform_loop(this_loop, transform_func, path_normal)


### PR DESCRIPTION
I know that extrude_along_path has a transform parameter to transform shape points during extrusion but it's not entirely sufficient to handle my use-case because I want to generate a scaled profile along the path with constant width, regardless of scale.

The attached patch implements something similar to the openscad skin function from list-comprehension-demos that takes as input a callable to generate the profile along the extrusion path. 

This patch is not really correct with regard to type checking (I did not change the type of the input shape_pts because I have no idea on how to specifiy a union between the native list type and a callable).

I'd be happy to revise the patch as needed based on your feedback.