### PR TITLE
Switch to correct dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,17 +44,5 @@ tox = "^tox 3.11"
 
 
 [build-system]
-requires = [
-    "poetry>=0.12",
-    # See https://github.com/pypa/setuptools/issues/2353#issuecomment-683781498
-    # for the rest of these requirements, 
-    # -ETJ 31 December 2020
-    "setuptools>=30.3.0,<50",
-    "wheel",
-    "pytest-runner",
-    "setuptools_scm>=3.3.1",
-
-]
-
-build-backend = "poetry.masonry.api"
-
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ euclid3 = "^0.1.0"
 pypng = "^0.0.19"
 PrettyTable = "=0.7.2"
 ply = "^3.11"
+setuptools = ">=65.6.3"
 
 [tool.poetry.dev-dependencies]
 tox = "^tox 3.11"


### PR DESCRIPTION
Switch to poetry-core as build-system (and remove all unused/unneeded build dependencies).
Add setuptools to dependency of the project, as it is in fact required directly (due to the use of `pkg_resources`).